### PR TITLE
Ratatouille token

### DIFF
--- a/src/Application/Interfaces/IUserRepository.py
+++ b/src/Application/Interfaces/IUserRepository.py
@@ -14,3 +14,7 @@ class IUserRepository(ABC):
     @abstractmethod
     def get_user_by_username(self, username):
         pass
+
+    @abstractmethod
+    def update_user_token(self, username: str, token: str, key: str | None = None) -> bool:
+        ...

--- a/src/Application/User/Services/TokenService.py
+++ b/src/Application/User/Services/TokenService.py
@@ -10,9 +10,10 @@ class TokenService(ITokenService):
         self.tz = pytz.timezone("America/Costa_Rica")
 
     def generate_token(self, user):
+        now = datetime.datetime.now(tz=self.tz)
         payload = {
-            "iat": datetime.datetime.now(tz=self.tz),
-            "exp": datetime.datetime.now(tz=self.tz) + datetime.timedelta(minutes=10),
+            "iat": now,
+            "exp": now + datetime.timedelta(minutes=60),
             "sub": user.id,
             "username": user.username
         }

--- a/src/Application/User/Services/UserApplicationService.py
+++ b/src/Application/User/Services/UserApplicationService.py
@@ -71,6 +71,7 @@ class UserApplicationService:
             return None, {'error': "Invalid username or password"}, 401
 
         token = self.token_service.generate_token(user)
+        self.user_repository.update_user_token(user.username, token, getattr(user, 'key', None))
 
         return user, {'message': "Login successful", 'token': token}, 200
 

--- a/src/Database/User/UserCSV.py
+++ b/src/Database/User/UserCSV.py
@@ -1,6 +1,7 @@
 import csv
 import os
-
+from tempfile import NamedTemporaryFile
+import shutil
 
 class UserCSV:
     def __init__(self, file_path):
@@ -12,7 +13,7 @@ class UserCSV:
             with open(self.file_path, 'w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerow(
-                    ['id', 'username', 'password', 'email', 'role'])
+                    ['id', 'username', 'password', 'email', 'role', 'key', 'token'])
 
     def user_exists(self, username, email):
         with open(self.file_path, 'r', newline='') as file:
@@ -38,13 +39,15 @@ class UserCSV:
             'username': user_dto.username,
             'password': user_dto.password,
             'email': user_dto.email,
-            'role': user_dto.role
+            'role': user_dto.role,
+            'key': getattr(user_dto, 'key', '') or '',
+            'token': ''
         }
 
         # Appends new user to CSV file
         with open(self.file_path, 'a', newline='') as file:
             writer = csv.DictWriter(
-                file, fieldnames=['id', 'username', 'password', 'email', 'role'])
+                file, fieldnames=['id', 'username', 'password', 'email', 'role', 'key', 'token'])
             writer.writerow(new_user)
 
         return new_user
@@ -56,3 +59,27 @@ class UserCSV:
                 if row['username'] == username:
                     return row
         return None
+    
+    def update_user_token(self, username, token, key=None):
+        updated = False
+        tmp = NamedTemporaryFile('w', delete=False, newline='')
+        with open(self.file_path, 'r', newline='') as src, tmp:
+            reader = csv.DictReader(src)
+            fieldnames = reader.fieldnames or ['id','username','password','email','role','key','token']
+            for col in ['key', 'token']:
+                if col not in fieldnames:
+                    fieldnames.append(col)
+            writer = csv.DictWriter(tmp, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in reader:
+                if row.get('username') == username:
+                    row['token'] = token
+                    if key is not None:
+                        row['key'] = key
+                    updated = True
+                for col in fieldnames:
+                    row.setdefault(col, '')
+                writer.writerow(row)
+
+        shutil.move(tmp.name, self.file_path)
+        return updated

--- a/src/Infrastructure/User/UserRepository.py
+++ b/src/Infrastructure/User/UserRepository.py
@@ -38,3 +38,6 @@ class UserRepository(IUserRepository):
                 role=db_user['role']
             )
         return None
+    
+    def update_user_token(self, username, token, key=None) -> bool:
+        return self.user_csv.update_user_token(username, token, key)


### PR DESCRIPTION
**Summary:**
Persist user JWTs (and per-user keys) in the CSV and update them on each login. Set the token expiration to 60 minutes.

**Test**
Register → CSV row created.
Login → 200 + token; CSV shows key and token updated.