### PR TITLE
Bbq log separate jsonfile

### DIFF
--- a/src/Shared/Logs/build_handlers.py
+++ b/src/Shared/Logs/build_handlers.py
@@ -17,6 +17,6 @@ def build_handlers(out_dir: str = "src/database/Logs"):
     )
 
     txt_handler = TxtFileHandler(str(Path(out_dir) / "GeneralLogs.txt"))
-    json_handler = JsonFileHandler(str(Path(out_dir) / "ImportantLogs.json"))
+    json_handler = JsonFileHandler(str(Path(out_dir)))
 
     return [console, txt_handler, json_handler]

--- a/src/Shared/Logs/json_file_handler.py
+++ b/src/Shared/Logs/json_file_handler.py
@@ -4,16 +4,19 @@ from pathlib import Path
 
 
 class JsonFileHandler(logging.Handler):
-    def __init__(self, path: str, level: int = logging.INFO):
+    def __init__(self, base_dir: str = "src/database/Logs", level: int = logging.INFO):
         super().__init__(level)
-        self.path = Path(path)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         self.formatter = logging.Formatter(datefmt="%Y-%m-%d %H:%M:%S")
+
+    def _get_file_for_action(self, action: str) -> Path:
+        safe_action = str(action).strip().replace(" ", "_").lower() or "general"
+        return self.base_dir / f"{safe_action}.json"
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
             timestamp = self.formatter.formatTime(record, self.formatter.datefmt)
-
             log_entry = {
                 "timestamp": timestamp,
                 "level": record.levelname,
@@ -24,10 +27,13 @@ class JsonFileHandler(logging.Handler):
                 "description": getattr(record, "description", "-"),
             }
 
+            action = getattr(record, "action", "general")
+            log_file = self._get_file_for_action(action)
+
             data = []
-            if self.path.exists():
+            if log_file.exists():
                 try:
-                    content = self.path.read_text(encoding="utf-8").strip()
+                    content = log_file.read_text(encoding="utf-8").strip()
                     if content:
                         data = json.loads(content)
                         if not isinstance(data, list):
@@ -36,7 +42,7 @@ class JsonFileHandler(logging.Handler):
                     data = []
 
             data.append(log_entry)
-            self.path.write_text(
+            log_file.write_text(
                 json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
             )
 

--- a/tests/Unittests/Logs/test_logger_jsonfile.py
+++ b/tests/Unittests/Logs/test_logger_jsonfile.py
@@ -8,11 +8,14 @@ from src.Shared.Logs.json_file_handler import JsonFileHandler
 class JsonFileHandlerAdvancedTests(unittest.TestCase):
 
     def setUp(self):
-        self.log_path = Path("testLogs.json")
-        if self.log_path.exists():
-            self.log_path.unlink()
+        self.log_dir = Path("test_logs")
+        if self.log_dir.exists():
+            for f in self.log_dir.glob("*.json"):
+                f.unlink()
+        else:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
 
-        handler = JsonFileHandler(str(self.log_path))
+        handler = JsonFileHandler(str(self.log_dir))
         self.logger = CustomLogger("TestLogger", handlers=[handler])
 
     def tearDown(self):
@@ -20,8 +23,10 @@ class JsonFileHandlerAdvancedTests(unittest.TestCase):
             handler.close()
         self.logger.logger.handlers.clear()
 
-        if self.log_path.exists():
-            self.log_path.unlink()
+        for f in self.log_dir.glob("*.json"):
+            f.unlink()
+        if self.log_dir.exists():
+            self.log_dir.rmdir()
 
     def _flush_and_close(self, logger):
         for handler in logger.logger.handlers:
@@ -29,15 +34,19 @@ class JsonFileHandlerAdvancedTests(unittest.TestCase):
             handler.close()
         logger.logger.handlers.clear()
 
+    def _read_log_file(self, action: str):
+        log_file = self.log_dir / f"{action.lower()}.json"
+        self.assertTrue(log_file.exists(), f"Expected log file {log_file} not found.")
+        with log_file.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
     def test_missing_optional_id_object_defaults_to_dash(self):
         self.logger.log(
             "info", "UserX", "admin", "delete", description="Intento sin id_object"
         )
         self._flush_and_close(self.logger)
 
-        with self.log_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-
+        data = self._read_log_file("delete")
         self.assertEqual(data[0]["id_object"], "-")
 
     def test_log_contains_all_expected_fields(self):
@@ -45,9 +54,7 @@ class JsonFileHandlerAdvancedTests(unittest.TestCase):
 
         self._flush_and_close(self.logger)
 
-        with self.log_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-
+        data = self._read_log_file("Action1")
         entry = data[0]
         expected_fields = {
             "timestamp",
@@ -67,18 +74,17 @@ class JsonFileHandlerAdvancedTests(unittest.TestCase):
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
 
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        log_file = temp_dir / "log.json"
-
-        handler = JsonFileHandler(str(log_file))
+        handler = JsonFileHandler(str(temp_dir))
         logger = CustomLogger("DirTestLogger", handlers=[handler])
 
-        logger.log("info", "U", "R", "A", "D", description="check dir")
+        logger.log("info", "U", "R", "TestAction", "1", description="check dir")
         for h in logger.logger.handlers:
             h.flush()
             h.close()
 
+        log_file = temp_dir / "testaction.json"
         self.assertTrue(log_file.exists())
+
         shutil.rmtree(temp_dir)
 
 


### PR DESCRIPTION

 **Description:**

This PR introduces the storage of logs in JSON files, automatically categorized by the `action` field.

**Testing:**

To test the implementation, you can either observe the pipeline execution or navigate to the project root (CI0136-II-2025-final-project) and run the following command:

   ```bash
   python -m src.Test.Logs
   ```


**Usage Example:**
The file located in src.Test.Logs provides an example of how to use the logger, which developers can reference when integrating logging into their own functionality.
