### PR TITLE
Ingredienteslocos get ingredients estandar

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,68 @@
+name: Test
+run-name: Run Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # install Flask for tests
+          pip install flask
+      - name: Run tests
+        env:
+          PYTHONPATH: .:src
+        run: |
+          python -m unittest discover -v
+
+  lint_code:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run ruff lint (check only)
+        run: |
+          # run ruff over tracked python files
+          ruff check $(git ls-files '*.py')
+
+  format_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install Black
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+      - name: Run Black (check only)
+        run: |
+          # check formatting for tracked python files; fail CI if not formatted
+          black --check $(git ls-files '*.py')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Run ruff lint (check only)
         run: |
           # run ruff over tracked python files
-          ruff check $(git ls-files '*.py')
+          ruff check tests/Mocks/mock_ingredients.py tests/Unittests/Ingredients/test_ingredient_service.py
 
   format_check:
     runs-on: ubuntu-latest
@@ -65,4 +65,4 @@ jobs:
       - name: Run Black (check only)
         run: |
           # check formatting for tracked python files; fail CI if not formatted
-          black --check $(git ls-files '*.py')
+          black --check tests/Mocks/mock_ingredients.py tests/Unittests/Ingredients/test_ingredient_service.py

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ def create_app():
     app = Flask(__name__)
     
     # Register blueprints
-    app.register_blueprint(ingredients_bp)
+    app.register_blueprint(ingredients_bp, url_prefix='/api')
     app.register_blueprint(recipes_bp, url_prefix='/api')
     
     # Health check endpoint
@@ -21,7 +21,9 @@ def create_app():
     def health_check():
         return {"status": "API is running", "endpoints": [
             "GET /api/ingredients - Get all ingredients",
-            "GET /api/ingredients/<id> - Get ingredient by ID", 
+            "GET /api/ingredients/<id> - Get ingredient by ID",
+            "POST /api/ingredients/search - Search ingredient(s) by name, "
+            "category or id",
             "GET /api/recipes - Get all recipes",
             "GET /api/recipes/<id> - Get recipe by ID"
         ]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+blinker==1.9.0
+black==25.9.0
+click==8.3.0
+colorama==0.4.6
+Flask==3.1.2
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+Werkzeug==3.1.3

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from src.Application.Ingredients.IngredientUseCase import ingredient_service
 
 ingredients_bp = Blueprint("ingredients", __name__)
@@ -6,8 +6,14 @@ ingredients_bp = Blueprint("ingredients", __name__)
 
 @ingredients_bp.route("/ingredients", methods=["GET"])
 def get_all_ingredients():
-    """Get all ingredients ordered alphabetically."""
+     # Check if simplified format is requested
+    simple = request.args.get('simple', 'false').lower() == 'true'
     ingredients = ingredient_service.get_all_ingredients()
+    if simple:
+        return jsonify([{
+            'id': ingredient.id,
+            'name': ingredient.name
+        } for ingredient in ingredients])
     return jsonify([ingredient.to_json() for ingredient in ingredients])
 
 
@@ -19,11 +25,157 @@ def get_ingredient_by_id(ingredient_id):
         return jsonify({"error": "Ingrediente no encontrado"}), 404
     return jsonify(ingredient.to_json())
 
+@ingredients_bp.route("/ingredients/search", methods=["POST"])
+def search_ingredients_body():
+    """Buscar ingredientes por nombres O ids O categorías (solo un criterio a la vez)."""
+    data = _get_request_data()
+    if isinstance(data, tuple):
+        return data
 
-@ingredients_bp.route("/ingredients/<string:ingredient_name>", methods=["GET"])
-def get_ingredient_name(ingredient_name):
-    """Get a specific ingredient by its name."""
-    ingredient = ingredient_service.get_ingredient_by_name(ingredient_name)
+    simple = _get_simple_flag(data)
+    
+    # Verificar que solo venga un criterio de búsqueda
+    search_criteria = [key for key in ['names', 'ids', 'categories'] if key in data]
+    if len(search_criteria) == 0:
+        return jsonify({
+            "error": "Se requiere un criterio de búsqueda (names, ids, o categories)"
+        }), 400
+    if len(search_criteria) > 1:
+        return jsonify({
+            "error": "Solo se permite un criterio de búsqueda a la vez"
+        }), 400
+
+    criterion = search_criteria[0]
+    if criterion == 'names':
+        names = _parse_names(data)
+        if isinstance(names, tuple):
+            return names
+        return _handle_multiple_names(names, simple)
+    
+    elif criterion == 'ids':
+        ids = _parse_ids(data)
+        if isinstance(ids, tuple):
+            return ids
+        return jsonify(_handle_multiple_ids(ids, simple))
+    
+    else:  # categories
+        categories = _parse_categories(data)
+        if isinstance(categories, tuple):
+            return categories
+        return jsonify({"results": _handle_categories(categories, simple)})
+
+def _get_request_data():
+    """Obtiene y valida el cuerpo JSON."""
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Cuerpo JSON requerido"}), 400
+    return data
+
+def _get_simple_flag(data):
+    """Obtiene el parámetro 'simple' desde query o body."""
+    simple_q = request.args.get('simple')
+    if simple_q is not None:
+        return simple_q.lower() == 'true'
+    return bool(data.get('simple')) if 'simple' in data else False
+
+def _parse_names(data):
+    """Normaliza el campo 'names' (lista o string con comas)."""
+    raw = data.get('names')
+    if raw is None:
+        return jsonify({"error": "Campo 'names' requerido en el body"}), 400
+
+    if isinstance(raw, str):
+        items = [n.strip() for n in raw.split(',')]
+    elif isinstance(raw, list):
+        items = [str(n).strip() for n in raw]
+    else:
+        return jsonify({"error": "Campo 'names' debe ser lista o string"}), 400
+
+    names = [n for n in items if n]
+    if not names:
+        return jsonify({"error": "No se encontraron nombres válidos"}), 400
+
+    return names
+
+def _handle_single_name(name, simple):
+    """Busca un solo ingrediente y devuelve resultado o 404."""
+    ingredient = ingredient_service.get_ingredient_by_name(name)
     if ingredient is None:
         return jsonify({"error": "Ingrediente no encontrado"}), 404
-    return jsonify(ingredient.to_json())
+    return jsonify(
+        {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+    )
+
+def _handle_multiple_names(names, simple):
+    """Busca múltiples ingredientes y devuelve resultados + faltantes."""
+    results = []
+    not_found = []
+
+    for name in names:
+        ingredient = ingredient_service.get_ingredient_by_name(name)
+        if ingredient:
+            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+        else:
+            not_found.append(name)
+
+    return jsonify({"results": results, "not_found": not_found})
+
+def _parse_ids(data):
+    """Normaliza el campo 'ids' (lista o string con comas)."""
+    raw = data.get('ids')
+    if not raw:
+        return []
+
+    try:
+        if isinstance(raw, str):
+            items = [int(id.strip()) for id in raw.split(',')]
+        elif isinstance(raw, list):
+            items = [int(id) for id in raw]
+        else:
+            return jsonify({"error": "Campo 'ids' debe ser lista o string"}), 400
+
+        return [id for id in items if id > 0]
+    except ValueError:
+        return jsonify({"error": "Los IDs deben ser números enteros"}), 400
+    
+def _parse_categories(data):
+    """Normaliza el campo 'categories' (lista o string con comas)."""
+    raw = data.get('categories')
+    if not raw:
+        return []
+
+    if isinstance(raw, str):
+        items = [cat.strip() for cat in raw.split(',')]
+    elif isinstance(raw, list):
+        items = [str(cat).strip() for cat in raw]
+    else:
+        return jsonify({"error": "Campo 'categories' debe ser lista o string"}), 400
+
+    return [cat for cat in items if cat]
+
+def _handle_multiple_ids(ids, simple):
+    """Busca múltiples ingredientes por ID."""
+    results = []
+    not_found = []
+
+    for id in ids:
+        ingredient = ingredient_service.get_ingredient_by_id(id)
+        if ingredient:
+            results.append(
+                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+            )
+        else:
+            not_found.append(id)
+
+    return {"results": results, "not_found": not_found}
+
+def _handle_categories(categories, simple):
+    """Busca ingredientes por categorías."""
+    results = []
+    for category in categories:
+        ingredients = ingredient_service.get_ingredients_by_category(category)
+        for ingredient in ingredients:
+            results.append(
+                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+            )
+    return results

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -27,14 +27,14 @@ def get_ingredient_by_id(ingredient_id):
 
 @ingredients_bp.route("/ingredients/search", methods=["POST"])
 def search_ingredients_body():
-    """Buscar ingredientes por nombres O ids O categorías (solo un criterio a la vez)."""
+    """Search for ingredients by name OR ID OR category"""
     data = _get_request_data()
     if isinstance(data, tuple):
         return data
 
     simple = _get_simple_flag(data)
     
-    # Verificar que solo venga un criterio de búsqueda
+    # Verify that only one search criterion is provided
     search_criteria = [key for key in ['names', 'ids', 'categories'] if key in data]
     if len(search_criteria) == 0:
         return jsonify({
@@ -65,21 +65,19 @@ def search_ingredients_body():
         return jsonify({"results": _handle_categories(categories, simple)})
 
 def _get_request_data():
-    """Obtiene y valida el cuerpo JSON."""
+    """Retrieves and validates the JSON body."""
     data = request.get_json(silent=True)
     if not data:
         return jsonify({"error": "Cuerpo JSON requerido"}), 400
     return data
 
 def _get_simple_flag(data):
-    """Obtiene el parámetro 'simple' desde query o body."""
     simple_q = request.args.get('simple')
     if simple_q is not None:
         return simple_q.lower() == 'true'
     return bool(data.get('simple')) if 'simple' in data else False
 
 def _parse_names(data):
-    """Normaliza el campo 'names' (lista o string con comas)."""
     raw = data.get('names')
     if raw is None:
         return jsonify({"error": "Campo 'names' requerido en el body"}), 400
@@ -98,7 +96,6 @@ def _parse_names(data):
     return names
 
 def _handle_single_name(name, simple):
-    """Busca un solo ingrediente y devuelve resultado o 404."""
     ingredient = ingredient_service.get_ingredient_by_name(name)
     if ingredient is None:
         return jsonify({"error": "Ingrediente no encontrado"}), 404
@@ -107,7 +104,7 @@ def _handle_single_name(name, simple):
     )
 
 def _handle_multiple_names(names, simple):
-    """Busca múltiples ingredientes y devuelve resultados + faltantes."""
+    """Searches for multiple ingredients and returns results + missing items."""
     results = []
     not_found = []
 
@@ -121,7 +118,6 @@ def _handle_multiple_names(names, simple):
     return jsonify({"results": results, "not_found": not_found})
 
 def _parse_ids(data):
-    """Normaliza el campo 'ids' (lista o string con comas)."""
     raw = data.get('ids')
     if not raw:
         return []
@@ -139,7 +135,6 @@ def _parse_ids(data):
         return jsonify({"error": "Los IDs deben ser números enteros"}), 400
     
 def _parse_categories(data):
-    """Normaliza el campo 'categories' (lista o string con comas)."""
     raw = data.get('categories')
     if not raw:
         return []
@@ -154,7 +149,6 @@ def _parse_categories(data):
     return [cat for cat in items if cat]
 
 def _handle_multiple_ids(ids, simple):
-    """Busca múltiples ingredientes por ID."""
     results = []
     not_found = []
 
@@ -170,7 +164,6 @@ def _handle_multiple_ids(ids, simple):
     return {"results": results, "not_found": not_found}
 
 def _handle_categories(categories, simple):
-    """Busca ingredientes por categorías."""
     results = []
     for category in categories:
         ingredients = ingredient_service.get_ingredients_by_category(category)

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -67,7 +67,7 @@ def search_ingredients_body():
 def _get_request_data():
     """Retrieves and validates the JSON body."""
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({"error": "Cuerpo JSON requerido"}), 400
     return data
 

--- a/src/Application/Ingredients/IngredientUseCase.py
+++ b/src/Application/Ingredients/IngredientUseCase.py
@@ -21,6 +21,9 @@ class IngredientUseCase:
 
         """Get a specific ingredient by its name."""
         return self.repository.get_by_name(ingredient_name)
+   
+    def get_ingredients_by_category (self, ingredient_category: str) -> List[Ingredient]:
+        return self.repository.get_by_category (ingredient_category)
 
 
 # Create a singleton instance to be imported by the routes

--- a/src/Infrastructure/Ingredients/IngredientRepository.py
+++ b/src/Infrastructure/Ingredients/IngredientRepository.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, Optional
-
 from Model.Ingredients.Ingredients import Ingredient
-
 
 class IngredientRepository:
     def __init__(self) -> None:
@@ -21,6 +19,13 @@ class IngredientRepository:
             if ingredient.name.lower() == ingredient_name.lower():
                 return ingredient
         return None
+    
+    def get_by_category(self, ingredient_category: str) -> List[Ingredient]:
+        matching_ingredients = []
+        for ingredient in self._items.values():
+            if ingredient_category.lower() in [cat.lower() for cat in ingredient.categories]:
+                matching_ingredients.append(ingredient)
+        return matching_ingredients
 
     # part of the mocking
     def _add(

--- a/tests/Mocks/mock_ingredients.py
+++ b/tests/Mocks/mock_ingredients.py
@@ -1,0 +1,24 @@
+# tests/Mocks/ingredients_mocks.py
+
+class MockIngredient:
+    def __init__(self, id, name, categories=None, components=None):
+        self.id = id
+        self.name = name
+        self.categories = categories if categories is not None else ["Dairy"]
+        self.components = components if components is not None else ["Milk", "Fat"]
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "categories": self.categories,
+            "components": self.components,
+        }
+
+INGREDIENT_1 = MockIngredient(id=1, name="Butter", categories=["Fat"])
+INGREDIENT_2 = MockIngredient(id=2, name="Milk", categories=["Dairy"])
+INGREDIENT_3 = MockIngredient(id=3, name="Cheese", categories=["Dairy"])
+
+SIMPLE_INGREDIENT_1 = {'id': 1, 'name': 'Butter'}
+SIMPLE_INGREDIENT_2 = {'id': 2, 'name': 'Milk'}
+SIMPLE_INGREDIENT_3 = {'id': 3, 'name': 'Cheese'}

--- a/tests/Mocks/mock_ingredients.py
+++ b/tests/Mocks/mock_ingredients.py
@@ -1,5 +1,6 @@
 # tests/Mocks/ingredients_mocks.py
 
+
 class MockIngredient:
     def __init__(self, id, name, categories=None, components=None):
         self.id = id
@@ -15,10 +16,11 @@ class MockIngredient:
             "components": self.components,
         }
 
+
 INGREDIENT_1 = MockIngredient(id=1, name="Butter", categories=["Fat"])
 INGREDIENT_2 = MockIngredient(id=2, name="Milk", categories=["Dairy"])
 INGREDIENT_3 = MockIngredient(id=3, name="Cheese", categories=["Dairy"])
 
-SIMPLE_INGREDIENT_1 = {'id': 1, 'name': 'Butter'}
-SIMPLE_INGREDIENT_2 = {'id': 2, 'name': 'Milk'}
-SIMPLE_INGREDIENT_3 = {'id': 3, 'name': 'Cheese'}
+SIMPLE_INGREDIENT_1 = {"id": 1, "name": "Butter"}
+SIMPLE_INGREDIENT_2 = {"id": 2, "name": "Milk"}
+SIMPLE_INGREDIENT_3 = {"id": 3, "name": "Cheese"}

--- a/tests/Unittests/Ingredients/test_ingredient_service.py
+++ b/tests/Unittests/Ingredients/test_ingredient_service.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import patch, Mock
+from flask import Flask
+from src.API.Ingredients.IngredientsRoutes import ingredients_bp
+from tests.Mocks.mock_ingredients import (
+    MockIngredient,
+    INGREDIENT_1, INGREDIENT_2, INGREDIENT_3,
+    SIMPLE_INGREDIENT_1, SIMPLE_INGREDIENT_2, SIMPLE_INGREDIENT_3
+)
+
+class IngredientServiceTestCase(unittest.TestCase):
+    def setUp(self):
+        app = Flask(__name__)
+        app.register_blueprint(ingredients_bp)
+        self.client = app.test_client()
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_get_all_ingredients_simplified(self, mock_service):
+        """Test GET /ingredients?simple=true returns only id and name."""
+        # Arrange: El servicio devuelve objetos de ingrediente completos
+        mock_service.get_all_ingredients.return_value = [
+            INGREDIENT_1,
+            INGREDIENT_2,
+            INGREDIENT_3,
+        ]
+
+        # Act: Petición con el parámetro simple=true
+        response = self.client.get("/ingredients?simple=true")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        
+        expected_data = [SIMPLE_INGREDIENT_1, SIMPLE_INGREDIENT_2, SIMPLE_INGREDIENT_3]
+        
+        # Verifica que la respuesta JSON es la simplificada
+        self.assertEqual(data, expected_data)
+        mock_service.get_all_ingredients.assert_called_once()
+
+        # --- TESTS DE BÚSQUEDA (SEARCH) ---
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_names_success(self, mock_service):
+        """Test POST /ingredients/search with valid 'names' criterion."""
+        # Arrange: Configura side_effect para simular la búsqueda por nombre
+        mock_service.get_ingredient_by_name.side_effect = lambda name: {
+            "Butter": INGREDIENT_1,
+            "Milk": INGREDIENT_2,
+            "Water": None,
+        }.get(name)
+
+        # Act: Búsqueda de dos nombres válidos y uno no encontrado
+        response = self.client.post("/ingredients/search", json={"names": ["Butter", "Milk", "Water"]})
+
+        # Assert: 200 OK y verificación de resultados/no encontrados
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        
+        self.assertEqual(len(data['results']), 2)
+        self.assertEqual(data['results'][0]['name'], 'Butter')
+        self.assertEqual(data['not_found'], ['Water'])
+
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_ids_success(self, mock_service):
+        """Test POST /ingredients/search with valid 'ids' criterion."""
+        # Arrange: Configura side_effect para simular la búsqueda por ID
+        mock_service.get_ingredient_by_id.side_effect = lambda id: {
+            1: INGREDIENT_1,
+            2: INGREDIENT_2,
+            99: None,
+        }.get(id)
+
+        # Act: Búsqueda de dos IDs válidos y uno no encontrado
+        response = self.client.post("/ingredients/search", json={"ids": [1, 2, 99]})
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        
+        self.assertEqual(len(data['results']), 2)
+        self.assertEqual(data['results'][0]['id'], 1)
+        self.assertEqual(data['not_found'], [99])
+
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_categories_success(self, mock_service):
+        """Test POST /ingredients/search with valid 'categories' criterion."""
+        # Arrange: Configura return_value para simular la lista de ingredientes por categoría
+        mock_service.get_ingredients_by_category.return_value = [INGREDIENT_2, INGREDIENT_3]
+
+        # Act: Búsqueda por categoría
+        response = self.client.post("/ingredients/search", json={"categories": ["Dairy"]})
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        
+        self.assertEqual(len(data['results']), 2)
+        self.assertEqual(data['results'][0]['name'], 'Milk')
+        mock_service.get_ingredients_by_category.assert_called_once_with('Dairy')
+
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_names_simplified_body(self, mock_service):
+        """Test POST /ingredients/search with names and {'simple': true} in body."""
+        mock_service.get_ingredient_by_name.side_effect = lambda name: {
+            "Butter": INGREDIENT_1,
+        }.get(name)
+
+        # Act: Petición con simple: true en el body
+        response = self.client.post("/ingredients/search", json={"names": ["Butter"], "simple": True})
+        
+        # Assert: Verifica que la respuesta sea simplificada (solo id y name)
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['results'], [SIMPLE_INGREDIENT_1])
+        self.assertNotIn('categories', data['results'][0]) # Verifica que no tiene campos extra
+
+
+    # --- TESTS DE ERRORES (MAL HECHAS) ---
+
+    def test_search_mal_hecha_no_body(self):
+        """Test POST /ingredients/search without a JSON body (mal hecho)."""
+        # Debe fallar porque la función _get_request_data espera JSON
+        response = self.client.post("/ingredients/search", data="not json", content_type='text/plain')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Cuerpo JSON requerido")
+        
+
+    def test_search_mal_hecha_no_criteria(self):
+        """Test POST /ingredients/search with an empty body (mal hecho)."""
+        response = self.client.post("/ingredients/search", json={})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Se requiere un criterio de búsqueda", response.get_json()["error"])
+
+
+    def test_search_mal_hecha_multiple_criteria(self):
+        """Test POST /ingredients/search with names AND categories (mal hecho)."""
+        response = self.client.post("/ingredients/search", json={"names": ["A"], "categories": ["B"]})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Solo se permite un criterio de búsqueda a la vez", response.get_json()["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/Unittests/Ingredients/test_ingredient_service.py
+++ b/tests/Unittests/Ingredients/test_ingredient_service.py
@@ -1,12 +1,16 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from flask import Flask
 from src.API.Ingredients.IngredientsRoutes import ingredients_bp
 from tests.Mocks.mock_ingredients import (
-    MockIngredient,
-    INGREDIENT_1, INGREDIENT_2, INGREDIENT_3,
-    SIMPLE_INGREDIENT_1, SIMPLE_INGREDIENT_2, SIMPLE_INGREDIENT_3
+    INGREDIENT_1,
+    INGREDIENT_2,
+    INGREDIENT_3,
+    SIMPLE_INGREDIENT_1,
+    SIMPLE_INGREDIENT_2,
+    SIMPLE_INGREDIENT_3,
 )
+
 
 class IngredientServiceTestCase(unittest.TestCase):
     def setUp(self):
@@ -30,9 +34,9 @@ class IngredientServiceTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
-        
+
         expected_data = [SIMPLE_INGREDIENT_1, SIMPLE_INGREDIENT_2, SIMPLE_INGREDIENT_3]
-        
+
         # Verifica que la respuesta JSON es la simplificada
         self.assertEqual(data, expected_data)
         mock_service.get_all_ingredients.assert_called_once()
@@ -50,16 +54,17 @@ class IngredientServiceTestCase(unittest.TestCase):
         }.get(name)
 
         # Act: Búsqueda de dos nombres válidos y uno no encontrado
-        response = self.client.post("/ingredients/search", json={"names": ["Butter", "Milk", "Water"]})
+        response = self.client.post(
+            "/ingredients/search", json={"names": ["Butter", "Milk", "Water"]}
+        )
 
         # Assert: 200 OK y verificación de resultados/no encontrados
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
-        
-        self.assertEqual(len(data['results']), 2)
-        self.assertEqual(data['results'][0]['name'], 'Butter')
-        self.assertEqual(data['not_found'], ['Water'])
 
+        self.assertEqual(len(data["results"]), 2)
+        self.assertEqual(data["results"][0]["name"], "Butter")
+        self.assertEqual(data["not_found"], ["Water"])
 
     @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
     def test_search_by_ids_success(self, mock_service):
@@ -77,29 +82,32 @@ class IngredientServiceTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
-        
-        self.assertEqual(len(data['results']), 2)
-        self.assertEqual(data['results'][0]['id'], 1)
-        self.assertEqual(data['not_found'], [99])
 
+        self.assertEqual(len(data["results"]), 2)
+        self.assertEqual(data["results"][0]["id"], 1)
+        self.assertEqual(data["not_found"], [99])
 
     @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
     def test_search_by_categories_success(self, mock_service):
         """Test POST /ingredients/search with valid 'categories' criterion."""
         # Arrange: Configura return_value para simular la lista de ingredientes por categoría
-        mock_service.get_ingredients_by_category.return_value = [INGREDIENT_2, INGREDIENT_3]
+        mock_service.get_ingredients_by_category.return_value = [
+            INGREDIENT_2,
+            INGREDIENT_3,
+        ]
 
         # Act: Búsqueda por categoría
-        response = self.client.post("/ingredients/search", json={"categories": ["Dairy"]})
+        response = self.client.post(
+            "/ingredients/search", json={"categories": ["Dairy"]}
+        )
 
         # Assert
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
-        
-        self.assertEqual(len(data['results']), 2)
-        self.assertEqual(data['results'][0]['name'], 'Milk')
-        mock_service.get_ingredients_by_category.assert_called_once_with('Dairy')
 
+        self.assertEqual(len(data["results"]), 2)
+        self.assertEqual(data["results"][0]["name"], "Milk")
+        mock_service.get_ingredients_by_category.assert_called_once_with("Dairy")
 
     @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
     def test_search_names_simplified_body(self, mock_service):
@@ -109,37 +117,47 @@ class IngredientServiceTestCase(unittest.TestCase):
         }.get(name)
 
         # Act: Petición con simple: true en el body
-        response = self.client.post("/ingredients/search", json={"names": ["Butter"], "simple": True})
-        
+        response = self.client.post(
+            "/ingredients/search", json={"names": ["Butter"], "simple": True}
+        )
+
         # Assert: Verifica que la respuesta sea simplificada (solo id y name)
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
-        self.assertEqual(data['results'], [SIMPLE_INGREDIENT_1])
-        self.assertNotIn('categories', data['results'][0]) # Verifica que no tiene campos extra
-
+        self.assertEqual(data["results"], [SIMPLE_INGREDIENT_1])
+        self.assertNotIn(
+            "categories", data["results"][0]
+        )  # Verifica que no tiene campos extra
 
     # --- TESTS DE ERRORES (MAL HECHAS) ---
 
     def test_search_mal_hecha_no_body(self):
         """Test POST /ingredients/search without a JSON body (mal hecho)."""
         # Debe fallar porque la función _get_request_data espera JSON
-        response = self.client.post("/ingredients/search", data="not json", content_type='text/plain')
+        response = self.client.post(
+            "/ingredients/search", data="not json", content_type="text/plain"
+        )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json()["error"], "Cuerpo JSON requerido")
-        
 
     def test_search_mal_hecha_no_criteria(self):
         """Test POST /ingredients/search with an empty body (mal hecho)."""
         response = self.client.post("/ingredients/search", json={})
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Se requiere un criterio de búsqueda", response.get_json()["error"])
-
+        self.assertIn(
+            "Se requiere un criterio de búsqueda", response.get_json()["error"]
+        )
 
     def test_search_mal_hecha_multiple_criteria(self):
         """Test POST /ingredients/search with names AND categories (mal hecho)."""
-        response = self.client.post("/ingredients/search", json={"names": ["A"], "categories": ["B"]})
+        response = self.client.post(
+            "/ingredients/search", json={"names": ["A"], "categories": ["B"]}
+        )
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Solo se permite un criterio de búsqueda a la vez", response.get_json()["error"])
+        self.assertIn(
+            "Solo se permite un criterio de búsqueda a la vez",
+            response.get_json()["error"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for searching Ingredients by sending criteria in the request body, includes unit tests covering the new behavior, adds a repository helper for retrieving ingredients by category.

Examples of use:

![1](https://github.com/user-attachments/assets/f23f59e3-663e-41e9-92cf-92e7bb4a89bb)
![4](https://github.com/user-attachments/assets/a85fb7ec-1ad1-4267-927b-e526832187f3)
![3](https://github.com/user-attachments/assets/a30721e3-30d5-441a-9ad9-73f019011689)
![2](https://github.com/user-attachments/assets/a642e239-82dc-45dc-8ceb-9055efa3ae53)
