### PR TITLE
Por Mientras Integrate User Authentication with Recipe Management

### DIFF
--- a/src/API/Recipes/recipesController.py
+++ b/src/API/Recipes/recipesController.py
@@ -1,8 +1,79 @@
+from flask import request
 from src.Application.Recipes import recipe_service
+from src.Infrastructure.User.UserRepository import UserRepository
+
+user_repository = UserRepository()
 
 
-def update_recipe_controller(recipe_id, updates, username):
+def get_username_from_request():
+    auth_header = request.headers.get('Authorization')
+    
+    if not auth_header:
+        return None
+    
+    parts = auth_header.split()
+    
+    if len(parts) != 2 or parts[0].lower() != 'bearer':
+        return None
+    
+    token = parts[1]
+    user_dto = user_repository.get_user_by_token(token)
+    return user_dto.username if user_dto else None
 
+
+def create_recipe_controller(data):
+    username = get_username_from_request()
+    
+    if not username:
+        return 401, {
+            "error": "Proporcione un token valido en Authorization: Bearer <token>"
+        }
+    
+    recipe = recipe_service.create_recipe(data, username)
+    
+    if recipe == -1:
+        return 400, {
+            "error": "Se necesita información adicional sobre la receta"
+        }
+    
+    return 201, {
+        "message": "Receta creada exitosamente",
+        "recipe": recipe.to_dict()
+    }
+
+
+def delete_recipe_controller(recipe_id):
+    username = get_username_from_request()
+    
+    if not username:
+        return 401, {
+            "error": "Proporcione un token valido en Authorization: Bearer <token>"
+        }
+    
+    result = recipe_service.delete_recipe(recipe_id, username)
+    
+    if result is None:
+        return 404, {"error": "Receta no encontrada"}
+    
+    if result is False:
+        return 403, {
+            "error": "No autorizado para eliminar esta receta"
+        }
+    
+    return 200, {
+        "message": "Receta eliminada",
+        "recipe": result.__str__()
+    }
+
+
+def update_recipe_controller(recipe_id, updates):
+    username = get_username_from_request()
+    
+    if not username:
+        return 401, {
+            "error": "Proporcione un token valido en Authorization: Bearer <token>"
+        }
+    
     allowed_fields = {
         "name",
         "categories",
@@ -12,14 +83,14 @@ def update_recipe_controller(recipe_id, updates, username):
         "portions",
     }
     safe_updates = {k: v for k, v in updates.items() if k in allowed_fields}
-
+    
     result = recipe_service.update_recipe(recipe_id, safe_updates, username)
-
+    
     if result == -1:
         return 400, {"error": "Datos de actualización inválidos"}
     if result is None:
         return 404, {"error": "Receta no encontrada"}
     if result is False:
         return 403, {"error": "No autorizado para editar esta receta"}
-
+    
     return 200, result.to_dict()

--- a/src/API/Recipes/recipesController.py
+++ b/src/API/Recipes/recipesController.py
@@ -6,16 +6,16 @@ user_repository = UserRepository()
 
 
 def get_username_from_request():
-    auth_header = request.headers.get('Authorization')
-    
+    auth_header = request.headers.get("Authorization")
+
     if not auth_header:
         return None
-    
+
     parts = auth_header.split()
-    
-    if len(parts) != 2 or parts[0].lower() != 'bearer':
+
+    if len(parts) != 2 or parts[0].lower() != "bearer":
         return None
-    
+
     token = parts[1]
     user_dto = user_repository.get_user_by_token(token)
     return user_dto.username if user_dto else None
@@ -23,57 +23,47 @@ def get_username_from_request():
 
 def create_recipe_controller(data):
     username = get_username_from_request()
-    
+
     if not username:
         return 401, {
             "error": "Proporcione un token valido en Authorization: Bearer <token>"
         }
-    
+
     recipe = recipe_service.create_recipe(data, username)
-    
+
     if recipe == -1:
-        return 400, {
-            "error": "Se necesita información adicional sobre la receta"
-        }
-    
-    return 201, {
-        "message": "Receta creada exitosamente",
-        "recipe": recipe.to_dict()
-    }
+        return 400, {"error": "Se necesita información adicional sobre la receta"}
+
+    return 201, {"message": "Receta creada exitosamente", "recipe": recipe.to_dict()}
 
 
 def delete_recipe_controller(recipe_id):
     username = get_username_from_request()
-    
+
     if not username:
         return 401, {
             "error": "Proporcione un token valido en Authorization: Bearer <token>"
         }
-    
+
     result = recipe_service.delete_recipe(recipe_id, username)
-    
+
     if result is None:
         return 404, {"error": "Receta no encontrada"}
-    
+
     if result is False:
-        return 403, {
-            "error": "No autorizado para eliminar esta receta"
-        }
-    
-    return 200, {
-        "message": "Receta eliminada",
-        "recipe": result.__str__()
-    }
+        return 403, {"error": "No autorizado para eliminar esta receta"}
+
+    return 200, {"message": "Receta eliminada", "recipe": result.__str__()}
 
 
 def update_recipe_controller(recipe_id, updates):
     username = get_username_from_request()
-    
+
     if not username:
         return 401, {
             "error": "Proporcione un token valido en Authorization: Bearer <token>"
         }
-    
+
     allowed_fields = {
         "name",
         "categories",
@@ -83,14 +73,14 @@ def update_recipe_controller(recipe_id, updates):
         "portions",
     }
     safe_updates = {k: v for k, v in updates.items() if k in allowed_fields}
-    
+
     result = recipe_service.update_recipe(recipe_id, safe_updates, username)
-    
+
     if result == -1:
         return 400, {"error": "Datos de actualización inválidos"}
     if result is None:
         return 404, {"error": "Receta no encontrada"}
     if result is False:
         return 403, {"error": "No autorizado para editar esta receta"}
-    
+
     return 200, result.to_dict()

--- a/src/API/Recipes/recipesRoutes.py
+++ b/src/API/Recipes/recipesRoutes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request
 from src.Application.Recipes import recipe_service
-from src.API.Recipes.recipesController import update_recipe_controller
+from src.API.Recipes import recipesController
 
 recipes_bp = Blueprint("recipes", __name__)
 
@@ -34,32 +34,20 @@ def get_recipes_by_ingredient(ingredient):
 @recipes_bp.route("/addrecipe", methods=["POST"])
 def create_recipe():
     data = request.json
-    username = "myUser"
-    recipe = recipe_service.create_recipe(data, username)
-    if recipe == -1:
-        return (
-            jsonify({"error": "Se necesita información adicional sobre la receta"}),
-            400,
-        )
-    return jsonify(recipe.to_dict())
+    status_code, response_data = recipesController.create_recipe_controller(data)
+    return jsonify(response_data), status_code
 
 
 @recipes_bp.route("/recipes/<int:recipe_id>", methods=["DELETE"])
 def delete_recipe(recipe_id):
-    username = "myUser"  # Change later to actual username
-    result = recipe_service.delete_recipe(recipe_id, username)
-    if result is None:
-        return jsonify({"error": "Receta no encontrada"}), 404
-    if result is False:
-        return jsonify({"error": "No autorizado para eliminar esta receta"}), 403
-    return jsonify({"message": "Receta eliminada", "recipe": result.__str__()})
+    status_code, response_data = recipesController.delete_recipe_controller(recipe_id)
+    return jsonify(response_data), status_code
 
 
 @recipes_bp.route("/recipes/<int:recipe_id>", methods=["PUT"])
 def update_recipe(recipe_id):
-    username = "myUser"  # Change later to actual username
     updates = request.json or {}
-    status_code, response_data = update_recipe_controller(recipe_id, updates, username)
+    status_code, response_data = recipesController.update_recipe_controller(recipe_id, updates)
     return jsonify(response_data), status_code
 
 

--- a/src/API/Recipes/recipesRoutes.py
+++ b/src/API/Recipes/recipesRoutes.py
@@ -47,7 +47,9 @@ def delete_recipe(recipe_id):
 @recipes_bp.route("/recipes/<int:recipe_id>", methods=["PUT"])
 def update_recipe(recipe_id):
     updates = request.json or {}
-    status_code, response_data = recipesController.update_recipe_controller(recipe_id, updates)
+    status_code, response_data = recipesController.update_recipe_controller(
+        recipe_id, updates
+    )
     return jsonify(response_data), status_code
 
 


### PR DESCRIPTION
This PR integrates user authentication into the recipes module.
Recipes are now linked to the authenticated user through the token sent in the Authorization header.
Only authenticated users can create, edit, or delete recipes

**Notes**
- Deletion/editing is restricted to the author of the recipe.
- Clients must send the token in the header:
`Authorization: Bearer <user_token>`
- For now, only username-based validation is implemented.
- Tokens are obtained during login.

**Token on request**
<img width="367" height="223" alt="image" src="https://github.com/user-attachments/assets/f086c4b3-c02e-4f4e-ba46-e93703d22714" />
