### PR TITLE
Ratatouille: Delete account (User & Profile)

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ def create_app():
                 "POST /auth/login",
                 "POST /auth/regenerate-key",
                 "POST /auth/change-password",
+                "DELETE /auth/delete-account - Deletes user account",
                 "GET /api/ingredients - Get all ingredients",
                 "GET /api/ingredients/<id> - Get ingredient by ID",
                 "GET /api/recipes - Get all recipes",

--- a/src/API/AuthRoutes.py
+++ b/src/API/AuthRoutes.py
@@ -21,7 +21,7 @@ encryption_service = EncryptionService()
 token_service = TokenService()
 profile_service = ProfileApplicationService(profile_repository=ProfileRepository())
 
-account_service = AccountApplicationService(
+account_app_service = AccountApplicationService(
     user_repository=user_repository,
     profile_service=profile_service,
     token_service=token_service,
@@ -128,7 +128,7 @@ def delete_account():
         return jsonify({"error": "Username to delete is required"}), 400
 
     # Call the service to delete the user account
-    user, response, status_code = account_service.delete_user_account(
+    user, response, status_code = account_app_service.delete_user_account(
         request.headers, username_to_delete
     )
 

--- a/src/API/AuthRoutes.py
+++ b/src/API/AuthRoutes.py
@@ -9,6 +9,9 @@ from src.Infrastructure.Profiles.ProfileRepository import ProfileRepository
 from src.Application.Profiles.Services.ProfileApplicationService import (
     ProfileApplicationService,
 )
+from src.Application.User.Services.AccountApplicationService import (
+    AccountApplicationService,
+)
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -17,6 +20,12 @@ validation_service = ValidationService()
 encryption_service = EncryptionService()
 token_service = TokenService()
 profile_service = ProfileApplicationService(profile_repository=ProfileRepository())
+
+account_service = AccountApplicationService(
+    user_repository=user_repository,
+    profile_service=profile_service,
+    token_service=token_service,
+)
 
 user_app_service = UserApplicationService(
     user_repository=user_repository,
@@ -111,41 +120,16 @@ def regenerate_key():
 
 @auth_bp.route("/delete-account", methods=["DELETE"])
 def delete_account():
-    auth = request.headers.get("Authorization", "")
-    parts = auth.split()
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        return jsonify({"error": "Missing or invalid Authorization header"}), 401
-    token = parts[1].strip()
+    # Get username to delete from request body
+    json_data = request.get_json()
+    username_to_delete = json_data.get("username") if json_data else None
 
-    try:
-        payload = jwt.decode(token, options={"verify_signature": False})
-        username = payload.get("username")
-        if not username:
-            return jsonify({"error": "Invalid token payload"}), 401
-    except jwt.InvalidTokenError:
-        return jsonify({"error": "Invalid token"}), 401
+    if not username_to_delete:
+        return jsonify({"error": "Username to delete is required"}), 400
 
-    user, resp, status = user_app_service.verify_valid_session(
-        request.headers, username
+    # Call the service to delete the user account
+    user, response, status_code = account_service.delete_user_account(
+        request.headers, username_to_delete
     )
-    if not user:
-        return jsonify(resp), status
 
-    # Search user to delete
-    json_user = request.get_json()
-    username_to_delete = json_user.get("username")
-    user_to_delete = user_repository.get_user_by_username(username_to_delete)
-    if not user_to_delete:
-        return jsonify({"error": "User not found"}), 404
-
-    # Delete user profile
-    profile_deleted = profile_service.delete_profile(user_to_delete.id)
-    if not profile_deleted:
-        return jsonify({"error": "Failed to delete user profile"}), 500
-
-    # Delete user account
-    user_deleted = user_repository.delete_user(user_to_delete.id)
-    if not user_deleted:
-        return jsonify({"error": "Failed to delete user account"}), 500
-
-    return jsonify({"message": "User account and profile deleted successfully"}), 200
+    return jsonify(response), status_code

--- a/src/API/AuthRoutes.py
+++ b/src/API/AuthRoutes.py
@@ -131,13 +131,20 @@ def delete_account():
     if not user:
         return jsonify(resp), status
 
+    # Search user to delete
+    json_user = request.get_json()
+    username_to_delete = json_user.get("username")
+    user_to_delete = user_repository.get_user_by_username(username_to_delete)
+    if not user_to_delete:
+        return jsonify({"error": "User not found"}), 404
+
     # Delete user profile
-    profile_deleted = profile_service.delete_profile(user.id)
+    profile_deleted = profile_service.delete_profile(user_to_delete.id)
     if not profile_deleted:
         return jsonify({"error": "Failed to delete user profile"}), 500
 
     # Delete user account
-    user_deleted = user_repository.delete_user(user.id)
+    user_deleted = user_repository.delete_user(user_to_delete.id)
     if not user_deleted:
         return jsonify({"error": "Failed to delete user account"}), 500
 

--- a/src/API/AuthRoutes.py
+++ b/src/API/AuthRoutes.py
@@ -108,6 +108,7 @@ def regenerate_key():
 
     return jsonify({"message": "Key regenerated successfully"}), 200
 
+
 @auth_bp.route("/delete-account", methods=["DELETE"])
 def delete_account():
     auth = request.headers.get("Authorization", "")

--- a/src/API/AuthRoutes.py
+++ b/src/API/AuthRoutes.py
@@ -107,3 +107,37 @@ def regenerate_key():
         return jsonify({"error": "Failed to rotate key"}), 500
 
     return jsonify({"message": "Key regenerated successfully"}), 200
+
+@auth_bp.route("/delete-account", methods=["DELETE"])
+def delete_account():
+    auth = request.headers.get("Authorization", "")
+    parts = auth.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return jsonify({"error": "Missing or invalid Authorization header"}), 401
+    token = parts[1].strip()
+
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+        username = payload.get("username")
+        if not username:
+            return jsonify({"error": "Invalid token payload"}), 401
+    except jwt.InvalidTokenError:
+        return jsonify({"error": "Invalid token"}), 401
+
+    user, resp, status = user_app_service.verify_valid_session(
+        request.headers, username
+    )
+    if not user:
+        return jsonify(resp), status
+
+    # Delete user profile
+    profile_deleted = profile_service.delete_profile(user.id)
+    if not profile_deleted:
+        return jsonify({"error": "Failed to delete user profile"}), 500
+
+    # Delete user account
+    user_deleted = user_repository.delete_user(user.id)
+    if not user_deleted:
+        return jsonify({"error": "Failed to delete user account"}), 500
+
+    return jsonify({"message": "User account and profile deleted successfully"}), 200

--- a/src/Application/Interfaces/IProfileApplicationService.py
+++ b/src/Application/Interfaces/IProfileApplicationService.py
@@ -6,3 +6,15 @@ class IProfileApplicationService(ABC):
     @abstractmethod
     def create_profile(self, user_id: int):
         pass
+
+    @abstractmethod
+    def get_profile(self, user_id: int):
+        pass
+
+    @abstractmethod
+    def set_favorite_ingredients(self, user_id: int, favorites: list):
+        pass
+
+    @abstractmethod
+    def delete_profile(self, user_id: int) -> bool:
+        pass

--- a/src/Application/Interfaces/IProfileApplicationService.py
+++ b/src/Application/Interfaces/IProfileApplicationService.py
@@ -12,9 +12,5 @@ class IProfileApplicationService(ABC):
         pass
 
     @abstractmethod
-    def set_favorite_ingredients(self, user_id: int, favorites: list):
-        pass
-
-    @abstractmethod
     def delete_profile(self, user_id: int) -> bool:
         pass

--- a/src/Application/Interfaces/IUserRepository.py
+++ b/src/Application/Interfaces/IUserRepository.py
@@ -25,3 +25,7 @@ class IUserRepository(ABC):
     @abstractmethod
     def update_user_key(self, username, new_key) -> bool:
         pass
+
+    @abstractmethod
+    def delete_user(self, user_id: int) -> bool:
+        pass

--- a/src/Application/Profiles/IProfileRepository.py
+++ b/src/Application/Profiles/IProfileRepository.py
@@ -45,3 +45,9 @@ class IProfileRepository(ABC):
         """Delete a user's profile.
         Returns True if successful. False on failure."""
         pass
+
+    @abstractmethod
+    def restore_profile(self, user_id: int, favorites: list) -> Optional[Profile]:
+        """Restore a user's profile with given favorite foods.
+        Returns the restored Profile if successful, None on failure."""
+        pass

--- a/src/Application/Profiles/IProfileRepository.py
+++ b/src/Application/Profiles/IProfileRepository.py
@@ -6,6 +6,7 @@ from src.Model.Profiles.Profiles import Profile
 class IProfileRepository(ABC):
     @abstractmethod
     def create_profile(self, user_id):
+        """Create a new profile for a user."""
         pass
 
     @abstractmethod
@@ -37,4 +38,10 @@ class IProfileRepository(ABC):
     @abstractmethod
     def is_menu_in_favorites(self, user_id: int, menu_id: str) -> bool:
         """Check if a menu is in user's favorites."""
+        pass
+
+    @abstractmethod
+    def delete_profile(self, user_id: int) -> bool:
+        """Delete a user's profile.
+        Returns True if successful. False on failure."""
         pass

--- a/src/Application/Profiles/Services/ProfileApplicationService.py
+++ b/src/Application/Profiles/Services/ProfileApplicationService.py
@@ -22,6 +22,6 @@ class ProfileApplicationService(IProfileApplicationService):
             f.replace("-", " ").strip().lower() for f in favorites if isinstance(f, str)
         ]
         return self.profile_repository.update_favorite_foods(user_id, favorites_norm)
-    
+
     def delete_profile(self, user_id):
         return self.profile_repository.delete_profile(user_id)

--- a/src/Application/Profiles/Services/ProfileApplicationService.py
+++ b/src/Application/Profiles/Services/ProfileApplicationService.py
@@ -25,3 +25,9 @@ class ProfileApplicationService(IProfileApplicationService):
 
     def delete_profile(self, user_id):
         return self.profile_repository.delete_profile(user_id)
+
+    def restore_profile(self, user_id: int, favorites: List[str]) -> Optional[Profile]:
+        favorites_norm = [
+            f.replace("-", " ").strip().lower() for f in favorites if isinstance(f, str)
+        ]
+        return self.profile_repository.restore_profile(user_id, favorites_norm)

--- a/src/Application/Profiles/Services/ProfileApplicationService.py
+++ b/src/Application/Profiles/Services/ProfileApplicationService.py
@@ -22,3 +22,6 @@ class ProfileApplicationService(IProfileApplicationService):
             f.replace("-", " ").strip().lower() for f in favorites if isinstance(f, str)
         ]
         return self.profile_repository.update_favorite_foods(user_id, favorites_norm)
+    
+    def delete_profile(self, user_id):
+        return self.profile_repository.delete_profile(user_id)

--- a/src/Application/User/Services/AccountApplicationService.py
+++ b/src/Application/User/Services/AccountApplicationService.py
@@ -1,0 +1,75 @@
+from src.Application.Interfaces.IUserRepository import IUserRepository
+from src.Application.Interfaces.ITokenService import ITokenService
+from src.Application.Profiles.Services.ProfileApplicationService import (
+    IProfileApplicationService,
+)
+import jwt
+
+
+class AccountApplicationService:
+    def __init__(
+        self,
+        user_repository: IUserRepository,
+        profile_service: IProfileApplicationService,
+        token_service: ITokenService,
+    ):
+        self.user_repository = user_repository
+        self.profile_service = profile_service
+        self.token_service = token_service
+
+    def _verify_valid_session(self, headers, username):
+        """Auxiliary method to verify if a session is valid based on headers and username.
+        (similar to UserApplicationService)"""
+        user = self.user_repository.get_user_by_username(username)
+        if not user:
+            return None, {"error": "User not found"}, 404
+
+        token = headers["Authorization"].split(" ")[1]
+
+        if self.token_service.verify_token(token, user):
+            return user, {"message": "Valid session"}, 200
+        else:
+            return None, {"error": "Expired session"}, 401
+
+    def delete_user_account(self, headers, username_to_delete):
+        # Validate and extract token
+        auth = headers.get("Authorization", "")
+        parts = auth.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            return None, {"error": "Missing or invalid Authorization header"}, 401
+
+        token = parts[1].strip()
+
+        try:
+            payload = jwt.decode(token, options={"verify_signature": False})
+            username = payload.get("username")
+            if not username:
+                return None, {"error": "Invalid token payload"}, 401
+        except jwt.InvalidTokenError:
+            return None, {"error": "Invalid token"}, 401
+
+        # Verify session
+        user, resp, status = self._verify_valid_session(headers, username)
+        if not user:
+            return None, resp, status
+
+        # Search for the user to delete
+        user_to_delete = self.user_repository.get_user_by_username(username_to_delete)
+        if not user_to_delete:
+            return None, {"error": "User not found"}, 404
+
+        # Delete user profile
+        profile_deleted = self.profile_service.delete_profile(user_to_delete.id)
+        if not profile_deleted:
+            return None, {"error": "Failed to delete user profile"}, 500
+
+        # Delete user account
+        user_deleted = self.user_repository.delete_user(user_to_delete.id)
+        if not user_deleted:
+            return None, {"error": "Failed to delete user account"}, 500
+
+        return (
+            user_to_delete,
+            {"message": "User account and profile deleted successfully"},
+            200,
+        )

--- a/src/Application/User/Services/AccountApplicationService.py
+++ b/src/Application/User/Services/AccountApplicationService.py
@@ -58,15 +58,23 @@ class AccountApplicationService:
         if not user_to_delete:
             return None, {"error": "User not found"}, 404
 
+        # Store profile before deletion
+        profile_to_delete = self.profile_service.get_profile(user_to_delete.id)
+        if not profile_to_delete:
+            return None, {"error": "User profile not found"}, 404
         # Delete user profile
         profile_deleted = self.profile_service.delete_profile(user_to_delete.id)
         if not profile_deleted:
             return None, {"error": "Failed to delete user profile"}, 500
-
-        # Delete user account
-        user_deleted = self.user_repository.delete_user(user_to_delete.id)
-        if not user_deleted:
-            return None, {"error": "Failed to delete user account"}, 500
+        if profile_deleted:
+            # Delete user account
+            user_deleted = self.user_repository.delete_user(user_to_delete.id)
+            if not user_deleted:
+                # Rollback profile deletion if user deletion fails
+                self.profile_service.restore_profile(
+                    user_to_delete.id, profile_to_delete.favorite_foods
+                )
+                return None, {"error": "Failed to delete user account"}, 500
 
         return (
             user_to_delete,

--- a/src/Application/User/Services/UserApplicationService.py
+++ b/src/Application/User/Services/UserApplicationService.py
@@ -187,3 +187,6 @@ class UserApplicationService:
             return None, {"error": "Failed to rotate key"}, 500
 
         return user, {"message": "Key regenerated successfully"}, 200
+    
+    def delete_user(self, user_id):
+        return self.user_repository.delete_user(user_id);

--- a/src/Application/User/Services/UserApplicationService.py
+++ b/src/Application/User/Services/UserApplicationService.py
@@ -187,6 +187,6 @@ class UserApplicationService:
             return None, {"error": "Failed to rotate key"}, 500
 
         return user, {"message": "Key regenerated successfully"}, 200
-    
+
     def delete_user(self, user_id):
-        return self.user_repository.delete_user(user_id);
+        return self.user_repository.delete_user(user_id)

--- a/src/Database/Profiles/ProfileCSV.py
+++ b/src/Database/Profiles/ProfileCSV.py
@@ -141,3 +141,25 @@ class ProfileCSV:
                 writer.writerows(rows)
 
         return updated
+    
+    def delete_profile(self, user_id: int) -> bool:
+        """Delete a profile by user_id"""
+        rows = []
+        deleted = False
+
+        with open(self.file_path, "r", newline="") as file:
+            reader = csv.DictReader(file)
+            fieldnames = reader.fieldnames
+            for row in reader:
+                if row["user_id"] == str(user_id):
+                    deleted = True
+                    continue  # Skip adding this row to the new list
+                rows.append(row)
+
+        if deleted:
+            with open(self.file_path, "w", newline="") as file:
+                writer = csv.DictWriter(file, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+        return deleted

--- a/src/Database/Profiles/ProfileCSV.py
+++ b/src/Database/Profiles/ProfileCSV.py
@@ -141,7 +141,7 @@ class ProfileCSV:
                 writer.writerows(rows)
 
         return updated
-    
+
     def delete_profile(self, user_id: int) -> bool:
         """Delete a profile by user_id"""
         rows = []

--- a/src/Database/User/UserCSV.py
+++ b/src/Database/User/UserCSV.py
@@ -145,7 +145,7 @@ class UserCSV:
             return True, "Password updated successfully", 200
 
         return False, "Failed to update password", 400
-    
+
     def delete_user(self, user_id: int) -> bool:
         """Delete a user by user_id"""
         rows = []

--- a/src/Database/User/UserCSV.py
+++ b/src/Database/User/UserCSV.py
@@ -145,3 +145,25 @@ class UserCSV:
             return True, "Password updated successfully", 200
 
         return False, "Failed to update password", 400
+    
+    def delete_user(self, user_id: int) -> bool:
+        """Delete a user by user_id"""
+        rows = []
+        deleted = False
+
+        with open(self.file_path, "r", newline="") as file:
+            reader = csv.DictReader(file)
+            fieldnames = reader.fieldnames
+            for row in reader:
+                if row["id"] == str(user_id):
+                    deleted = True
+                    continue  # Skip adding this row to the new list
+                rows.append(row)
+
+        if deleted:
+            with open(self.file_path, "w", newline="") as file:
+                writer = csv.DictWriter(file, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+        return deleted

--- a/src/Infrastructure/Profiles/ProfileRepository.py
+++ b/src/Infrastructure/Profiles/ProfileRepository.py
@@ -107,3 +107,32 @@ class ProfileRepository(IProfileRepository):
         """Delete a user's profile.
         Returns True if successful. False on failure."""
         return self.profile_database.delete_profile(user_id)
+
+    def restore_profile(self, user_id: int, favorites: list) -> Optional[Profile]:
+        profile_data = {
+            "user_id": user_id,
+            "favorite_foods": favorites,
+            "unfavorite_foods": [],
+            "favorite_menus": [],
+        }
+        restored_profile_data = self.profile_database.create_profile(profile_data)
+        if restored_profile_data:
+            return Profile(
+                user_id=int(restored_profile_data["user_id"]),
+                favorite_foods=(
+                    restored_profile_data["favorite_foods"].split(";")
+                    if restored_profile_data["favorite_foods"]
+                    else []
+                ),
+                unfavorite_foods=(
+                    restored_profile_data["unfavorite_foods"].split(";")
+                    if restored_profile_data["unfavorite_foods"]
+                    else []
+                ),
+                favorite_menus=(
+                    restored_profile_data["favorite_menus"].split(";")
+                    if restored_profile_data["favorite_menus"]
+                    else []
+                ),
+            )
+        return None

--- a/src/Infrastructure/Profiles/ProfileRepository.py
+++ b/src/Infrastructure/Profiles/ProfileRepository.py
@@ -102,7 +102,7 @@ class ProfileRepository(IProfileRepository):
     def is_menu_in_favorites(self, user_id: int, menu_id: str) -> bool:
         """Check if a menu is in user's favorites"""
         return menu_id in self.get_favorite_menus(user_id)
-    
+
     def delete_profile(self, user_id: int) -> bool:
         """Delete a user's profile.
         Returns True if successful. False on failure."""

--- a/src/Infrastructure/Profiles/ProfileRepository.py
+++ b/src/Infrastructure/Profiles/ProfileRepository.py
@@ -102,3 +102,8 @@ class ProfileRepository(IProfileRepository):
     def is_menu_in_favorites(self, user_id: int, menu_id: str) -> bool:
         """Check if a menu is in user's favorites"""
         return menu_id in self.get_favorite_menus(user_id)
+    
+    def delete_profile(self, user_id: int) -> bool:
+        """Delete a user's profile.
+        Returns True if successful. False on failure."""
+        return self.profile_database.delete_profile(user_id)

--- a/src/Infrastructure/User/UserRepository.py
+++ b/src/Infrastructure/User/UserRepository.py
@@ -62,3 +62,6 @@ class UserRepository(IUserRepository):
 
     def update_user_key(self, username, new_key) -> bool:
         return self.user_csv.update_user_key(username, new_key)
+
+    def delete_user(self, user_id: int) -> bool:
+        return self.user_csv.delete_user(user_id)

--- a/tests/Mocks/Profile/mock_profile_and_favorite_foods.py
+++ b/tests/Mocks/Profile/mock_profile_and_favorite_foods.py
@@ -57,3 +57,9 @@ class MockProfileAndFavoriteFoods(IProfileRepository):
         if not profile:
             return False
         return menu_id in profile.favorite_menus
+
+    def delete_profile(self, user_id: int) -> bool:
+        if user_id in self.profiles:
+            del self.profiles[user_id]
+            return True
+        return False

--- a/tests/Mocks/Profile/mock_profile_and_favorite_foods.py
+++ b/tests/Mocks/Profile/mock_profile_and_favorite_foods.py
@@ -63,3 +63,15 @@ class MockProfileAndFavoriteFoods(IProfileRepository):
             del self.profiles[user_id]
             return True
         return False
+
+    def restore_profile(self, user_id: int, favorites) -> Profile:
+        if user_id in self.profiles:
+            return None
+        profile = Profile(
+            user_id=user_id,
+            favorite_foods=favorites,
+            unfavorite_foods=[],
+            favorite_menus=[],
+        )
+        self.profiles[user_id] = profile
+        return profile

--- a/tests/Mocks/Profile/mock_profile_service.py
+++ b/tests/Mocks/Profile/mock_profile_service.py
@@ -11,3 +11,16 @@ class MockProfileService(IProfileApplicationService):
         profile = {"user_id": user_id, "profile_id": len(self.created_profiles) + 1}
         self.created_profiles.append(profile)
         return profile
+
+    def get_profile(self, user_id: int):
+        for profile in self.created_profiles:
+            if profile["user_id"] == user_id:
+                return profile
+        return None
+
+    def delete_profile(self, user_id: int):
+        for profile in self.created_profiles:
+            if profile["user_id"] == user_id:
+                self.created_profiles.remove(profile)
+                return True
+        return False

--- a/tests/Mocks/Users/mock_user_repo.py
+++ b/tests/Mocks/Users/mock_user_repo.py
@@ -64,3 +64,10 @@ class MockUserRepository(IUserRepository):
                 user.password = hashed_password
                 return True, "Password updated successfully", 200
         return False, "Failed to update password", 400
+
+    def delete_user(self, user_id: int) -> bool:
+        for user in self._users:
+            if user.id == user_id:
+                self._users.remove(user)
+                return True
+        return False

--- a/tests/Unittests/Profile/test_profile_repository.py
+++ b/tests/Unittests/Profile/test_profile_repository.py
@@ -2,6 +2,7 @@
 import unittest
 import os
 import tempfile
+import unittest.mock
 from src.Infrastructure.Profiles.ProfileRepository import ProfileRepository
 from src.Model.Profiles.Profiles import Profile
 

--- a/tests/Unittests/User/test_account_application_service.py
+++ b/tests/Unittests/User/test_account_application_service.py
@@ -36,6 +36,10 @@ class TestAccountApplicationService(unittest.TestCase):
         user_to_delete.id = 123
         user_to_delete.username = username_to_delete
 
+        # Mock profile to delete
+        mock_profile = Mock()
+        mock_profile.favorite_foods = ["pizza", "pasta"]
+
         # Mock token validation
         with patch("jwt.decode") as mock_jwt_decode:
             mock_jwt_decode.return_value = {"username": "authenticatedUser"}
@@ -48,6 +52,7 @@ class TestAccountApplicationService(unittest.TestCase):
             self.mock_token_service.verify_token.return_value = True
 
             # Mock successful deletions
+            self.mock_profile_service.get_profile.return_value = mock_profile
             self.mock_profile_service.delete_profile.return_value = True
             self.mock_user_repository.delete_user.return_value = True
 
@@ -64,8 +69,11 @@ class TestAccountApplicationService(unittest.TestCase):
             self.assertEqual(status_code, 200)
 
             # Verify method calls
+            self.mock_profile_service.get_profile.assert_called_once_with(123)
             self.mock_profile_service.delete_profile.assert_called_once_with(123)
             self.mock_user_repository.delete_user.assert_called_once_with(123)
+            # Verify restore_profile was NOT called (success case)
+            self.mock_profile_service.restore_profile.assert_not_called()
 
     def test_delete_user_account_missing_authorization_header(self):
         """Test deletion with missing Authorization header"""
@@ -191,8 +199,8 @@ class TestAccountApplicationService(unittest.TestCase):
             self.assertEqual(response["error"], "User not found")
             self.assertEqual(status_code, 404)
 
-    def test_delete_user_account_profile_deletion_fails(self):
-        """Test when profile deletion fails"""
+    def test_delete_user_account_profile_not_found(self):
+        """Test when user profile is not found"""
         # Arrange
         headers = {"Authorization": "Bearer valid_token"}
         username_to_delete = "userToDelete"
@@ -201,6 +209,44 @@ class TestAccountApplicationService(unittest.TestCase):
         authenticated_user = Mock()
         user_to_delete = Mock()
         user_to_delete.id = 123
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            self.mock_user_repository.get_user_by_username.side_effect = [
+                authenticated_user,
+                user_to_delete,
+            ]
+            self.mock_token_service.verify_token.return_value = True
+
+            # Mock profile not found
+            self.mock_profile_service.get_profile.return_value = None
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "User profile not found")
+            self.assertEqual(status_code, 404)
+
+    def test_delete_user_account_profile_deletion_fails(self):
+        """Test when profile deletion fails - user should NOT be deleted"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock authenticated user and user to delete
+        authenticated_user = Mock()
+        user_to_delete = Mock()
+        user_to_delete.id = 123
+
+        # Mock profile to delete
+        mock_profile = Mock()
+        mock_profile.favorite_foods = ["pizza", "pasta"]
 
         # Mock token validation
         with patch("jwt.decode") as mock_jwt_decode:
@@ -213,6 +259,7 @@ class TestAccountApplicationService(unittest.TestCase):
             self.mock_token_service.verify_token.return_value = True
 
             # Mock profile deletion failure
+            self.mock_profile_service.get_profile.return_value = mock_profile
             self.mock_profile_service.delete_profile.return_value = False
 
             # Act
@@ -225,8 +272,13 @@ class TestAccountApplicationService(unittest.TestCase):
             self.assertEqual(response["error"], "Failed to delete user profile")
             self.assertEqual(status_code, 500)
 
-    def test_delete_user_account_user_deletion_fails(self):
-        """Test when user account deletion fails"""
+            # Verify user deletion was NOT attempted when profile deletion fails
+            self.mock_user_repository.delete_user.assert_not_called()
+            # Verify restore_profile was NOT called (only for user deletion failure)
+            self.mock_profile_service.restore_profile.assert_not_called()
+
+    def test_delete_user_account_user_deletion_fails_with_rollback(self):
+        """Test when user account deletion fails - profile should be restored"""
         # Arrange
         headers = {"Authorization": "Bearer valid_token"}
         username_to_delete = "userToDelete"
@@ -235,6 +287,10 @@ class TestAccountApplicationService(unittest.TestCase):
         authenticated_user = Mock()
         user_to_delete = Mock()
         user_to_delete.id = 123
+
+        # Mock profile to delete
+        mock_profile = Mock()
+        mock_profile.favorite_foods = ["pizza", "pasta"]
 
         # Mock token validation
         with patch("jwt.decode") as mock_jwt_decode:
@@ -247,6 +303,7 @@ class TestAccountApplicationService(unittest.TestCase):
             self.mock_token_service.verify_token.return_value = True
 
             # Mock profile deletion success but user deletion failure
+            self.mock_profile_service.get_profile.return_value = mock_profile
             self.mock_profile_service.delete_profile.return_value = True
             self.mock_user_repository.delete_user.return_value = False
 
@@ -259,6 +316,11 @@ class TestAccountApplicationService(unittest.TestCase):
             self.assertIsNone(result_user)
             self.assertEqual(response["error"], "Failed to delete user account")
             self.assertEqual(status_code, 500)
+
+            # Verify rollback was attempted
+            self.mock_profile_service.restore_profile.assert_called_once_with(
+                123, mock_profile.favorite_foods
+            )
 
     def test_delete_user_account_authenticated_user_not_found(self):
         """Test when authenticated user is not found in database"""

--- a/tests/Unittests/User/test_account_application_service.py
+++ b/tests/Unittests/User/test_account_application_service.py
@@ -1,0 +1,288 @@
+import unittest
+from unittest.mock import Mock, patch
+import jwt
+from src.Application.User.Services.AccountApplicationService import (
+    AccountApplicationService,
+)
+
+
+class TestAccountApplicationService(unittest.TestCase):
+
+    def setUp(self):
+        # Create mocks for dependencies
+        self.mock_user_repository = Mock()
+        self.mock_profile_service = Mock()
+        self.mock_token_service = Mock()
+
+        # Initialize service with mocks
+        self.account_service = AccountApplicationService(
+            user_repository=self.mock_user_repository,
+            profile_service=self.mock_profile_service,
+            token_service=self.mock_token_service,
+        )
+
+    def test_delete_user_account_success(self):
+        """Test successful account deletion"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock authenticated user
+        authenticated_user = Mock()
+        authenticated_user.username = "authenticatedUser"
+
+        # Mock user to delete
+        user_to_delete = Mock()
+        user_to_delete.id = 123
+        user_to_delete.username = username_to_delete
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            # Mock session verification
+            self.mock_user_repository.get_user_by_username.side_effect = [
+                authenticated_user,
+                user_to_delete,
+            ]
+            self.mock_token_service.verify_token.return_value = True
+
+            # Mock successful deletions
+            self.mock_profile_service.delete_profile.return_value = True
+            self.mock_user_repository.delete_user.return_value = True
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertEqual(result_user, user_to_delete)
+            self.assertEqual(
+                response["message"], "User account and profile deleted successfully"
+            )
+            self.assertEqual(status_code, 200)
+
+            # Verify method calls
+            self.mock_profile_service.delete_profile.assert_called_once_with(123)
+            self.mock_user_repository.delete_user.assert_called_once_with(123)
+
+    def test_delete_user_account_missing_authorization_header(self):
+        """Test deletion with missing Authorization header"""
+        # Arrange
+        headers = {}
+        username_to_delete = "userToDelete"
+
+        # Act
+        result_user, response, status_code = self.account_service.delete_user_account(
+            headers, username_to_delete
+        )
+
+        # Assert
+        self.assertIsNone(result_user)
+        self.assertEqual(response["error"], "Missing or invalid Authorization header")
+        self.assertEqual(status_code, 401)
+
+    def test_delete_user_account_invalid_token_format(self):
+        """Test deletion with invalid token format"""
+        # Arrange
+        headers = {"Authorization": "InvalidFormat"}
+        username_to_delete = "userToDelete"
+
+        # Act
+        result_user, response, status_code = self.account_service.delete_user_account(
+            headers, username_to_delete
+        )
+
+        # Assert
+        self.assertIsNone(result_user)
+        self.assertEqual(response["error"], "Missing or invalid Authorization header")
+        self.assertEqual(status_code, 401)
+
+    def test_delete_user_account_invalid_token(self):
+        """Test deletion with invalid JWT token"""
+        # Arrange
+        headers = {"Authorization": "Bearer invalid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock invalid token
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.side_effect = jwt.InvalidTokenError("Invalid token")
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "Invalid token")
+            self.assertEqual(status_code, 401)
+
+    def test_delete_user_account_invalid_token_payload(self):
+        """Test deletion with token missing username"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock token without username
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"other_field": "value"}
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "Invalid token payload")
+            self.assertEqual(status_code, 401)
+
+    def test_delete_user_account_expired_session(self):
+        """Test deletion with expired session"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            # Mock session verification failure
+            self.mock_user_repository.get_user_by_username.return_value = Mock()
+            self.mock_token_service.verify_token.return_value = False
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "Expired session")
+            self.assertEqual(status_code, 401)
+
+    def test_delete_user_account_user_not_found(self):
+        """Test deletion when user to delete doesn't exist"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "nonExistentUser"
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            # Mock session verification success
+            authenticated_user = Mock()
+            self.mock_user_repository.get_user_by_username.side_effect = [
+                authenticated_user,
+                None,  # Second call for user to delete (not found)
+            ]
+            self.mock_token_service.verify_token.return_value = True
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "User not found")
+            self.assertEqual(status_code, 404)
+
+    def test_delete_user_account_profile_deletion_fails(self):
+        """Test when profile deletion fails"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock authenticated user and user to delete
+        authenticated_user = Mock()
+        user_to_delete = Mock()
+        user_to_delete.id = 123
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            self.mock_user_repository.get_user_by_username.side_effect = [
+                authenticated_user,
+                user_to_delete,
+            ]
+            self.mock_token_service.verify_token.return_value = True
+
+            # Mock profile deletion failure
+            self.mock_profile_service.delete_profile.return_value = False
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "Failed to delete user profile")
+            self.assertEqual(status_code, 500)
+
+    def test_delete_user_account_user_deletion_fails(self):
+        """Test when user account deletion fails"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock authenticated user and user to delete
+        authenticated_user = Mock()
+        user_to_delete = Mock()
+        user_to_delete.id = 123
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            self.mock_user_repository.get_user_by_username.side_effect = [
+                authenticated_user,
+                user_to_delete,
+            ]
+            self.mock_token_service.verify_token.return_value = True
+
+            # Mock profile deletion success but user deletion failure
+            self.mock_profile_service.delete_profile.return_value = True
+            self.mock_user_repository.delete_user.return_value = False
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "Failed to delete user account")
+            self.assertEqual(status_code, 500)
+
+    def test_delete_user_account_authenticated_user_not_found(self):
+        """Test when authenticated user is not found in database"""
+        # Arrange
+        headers = {"Authorization": "Bearer valid_token"}
+        username_to_delete = "userToDelete"
+
+        # Mock token validation
+        with patch("jwt.decode") as mock_jwt_decode:
+            mock_jwt_decode.return_value = {"username": "authenticatedUser"}
+
+            # Mock user not found for authenticated user
+            self.mock_user_repository.get_user_by_username.return_value = None
+
+            # Act
+            result_user, response, status_code = (
+                self.account_service.delete_user_account(headers, username_to_delete)
+            )
+
+            # Assert
+            self.assertIsNone(result_user)
+            self.assertEqual(response["error"], "User not found")
+            self.assertEqual(status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Account deletion
Feature for deleting a user and profile.
- Route: auth/delete-account
## Important notes
Currently, any user can delete any other user including themselves. Team BBQ is in charge of verifying that the user has the appropriate permissions (for example, that only admins can delete any user, and normal users can only delete their own account) 
## Requirements for deletion
- Json: Valid username. For example: ` "username": "JaneDoe" `
- Valid bearer token
## Error cases
An appropriate message is sent in cases like invalid token, failure to delete user and/or profile, and username not found.
