### PR TITLE
Ingredienteslocos fix get ingredients estandar

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def create_app():
     app.json.ensure_ascii = False
 
     # Register blueprints
-    app.register_blueprint(ingredients_bp)
+    app.register_blueprint(ingredients_bp, url_prefix="/api")
     app.register_blueprint(recipes_bp, url_prefix="/api")
     app.register_blueprint(menu_bp, url_prefix="/api")
     app.register_blueprint(auth_bp, url_prefix="/auth")

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -109,23 +109,25 @@ def search_ingredients_body():
         }), 400
 
     criterion = search_criteria[0]
-    if criterion == 'names':
+    if criterion == "names":
         names = _parse_names(data)
         if isinstance(names, tuple):
             return names
+        if len(names) == 1:
+            return _handle_single_name(names[0], simple)
         return _handle_multiple_names(names, simple)
     
     elif criterion == 'ids':
         ids = _parse_ids(data)
         if isinstance(ids, tuple):
             return ids
-        return jsonify(_handle_multiple_ids(ids, simple))
+        return _handle_multiple_ids(ids, simple)
     
     else:  # categories
         categories = _parse_categories(data)
         if isinstance(categories, tuple):
             return categories
-        return jsonify({"results": _handle_categories(categories, simple)})
+        return _handle_categories(categories, simple)
 
 def _get_request_data():
     """Retrieves and validates the JSON body."""
@@ -135,6 +137,7 @@ def _get_request_data():
     return data
 
 def _get_simple_flag(data):
+    """Query param ?simple=true overrides body.simple"""
     simple_q = request.args.get('simple')
     if simple_q is not None:
         return simple_q.lower() == 'true'
@@ -170,15 +173,13 @@ def _handle_multiple_names(names, simple):
     """Searches for multiple ingredients and returns results + missing items."""
     results = []
     not_found = []
-
     for name in names:
         ingredient = ingredient_service.get_ingredient_by_name(name)
         if ingredient:
             results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
         else:
             not_found.append(name)
-
-    return jsonify({"results": results, "not_found": not_found})
+    return jsonify({"results": results, "not_found": not_found}), 200
 
 def _parse_ids(data):
     raw = data.get('ids')
@@ -214,25 +215,26 @@ def _parse_categories(data):
 def _handle_multiple_ids(ids, simple):
     results = []
     not_found = []
-
-    for id in ids:
-        ingredient = ingredient_service.get_ingredient_by_id(id)
+    for iid in ids:
+        ingredient = ingredient_service.get_ingredient_by_id(iid)
         if ingredient:
-            results.append(
-                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
-            )
+            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
         else:
-            not_found.append(id)
-
-    return {"results": results, "not_found": not_found}
+            not_found.append(iid)
+    return jsonify({"results": results, "not_found": not_found}), 200
 
 def _handle_categories(categories, simple):
     results = []
     for category in categories:
         ingredients = ingredient_service.get_ingredients_by_category(category)
         for ingredient in ingredients:
-            results.append(
-                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
-            )
-    return results
-    return jsonify(ingredient.to_json())
+            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+    # remove duplicates by id
+    unique = []
+    seen = set()
+    for r in results:
+        iid = r["id"]
+        if iid not in seen:
+            seen.add(iid)
+            unique.append(r)
+    return jsonify({"results": unique}), 200

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -6,8 +6,14 @@ ingredients_bp = Blueprint("ingredients", __name__)
 
 @ingredients_bp.route("/ingredients", methods=["GET"])
 def get_all_ingredients():
-    """Get all ingredients ordered alphabetically."""
+    # Check if simplified format is requested
+    simple = request.args.get('simple', 'false').lower() == 'true'
     ingredients = ingredient_service.get_all_ingredients()
+    if simple:
+        return jsonify([{
+            'id': ingredient.id,
+            'name': ingredient.name
+        } for ingredient in ingredients])
     return jsonify([ingredient.to_json() for ingredient in ingredients])
 
 
@@ -18,16 +24,6 @@ def get_ingredient_by_id(ingredient_id):
     if not ingredient:
         return jsonify({"error": "Ingrediente no encontrado"}), 404
     return jsonify(ingredient.to_json())
-
-
-@ingredients_bp.route("/ingredients/<string:ingredient_name>", methods=["GET"])
-def get_ingredient_name(ingredient_name):
-    """Get a specific ingredient by its name."""
-    ingredient = ingredient_service.get_ingredient_by_name(ingredient_name)
-    if ingredient is None:
-        return jsonify({"error": "Ingrediente no encontrado"}), 404
-    return jsonify(ingredient.to_json())
-
 
 @ingredients_bp.route("/ingredients/create", methods=["POST"])
 def create_new_ingredient():
@@ -91,3 +87,152 @@ def delete_ingredient():
         return jsonify({"error": "Ingredient not found"}), 404
 
     return jsonify({"message": "Ingredient deleted successfully"}), 200
+
+@ingredients_bp.route("/ingredients/search", methods=["POST"])
+def search_ingredients_body():
+    """Search for ingredients by name OR ID OR category"""
+    data = _get_request_data()
+    if isinstance(data, tuple):
+        return data
+
+    simple = _get_simple_flag(data)
+    
+    # Verify that only one search criterion is provided
+    search_criteria = [key for key in ['names', 'ids', 'categories'] if key in data]
+    if len(search_criteria) == 0:
+        return jsonify({
+            "error": "Se requiere un criterio de búsqueda (names, ids, o categories)"
+        }), 400
+    if len(search_criteria) > 1:
+        return jsonify({
+            "error": "Solo se permite un criterio de búsqueda a la vez"
+        }), 400
+
+    criterion = search_criteria[0]
+    if criterion == 'names':
+        names = _parse_names(data)
+        if isinstance(names, tuple):
+            return names
+        return _handle_multiple_names(names, simple)
+    
+    elif criterion == 'ids':
+        ids = _parse_ids(data)
+        if isinstance(ids, tuple):
+            return ids
+        return jsonify(_handle_multiple_ids(ids, simple))
+    
+    else:  # categories
+        categories = _parse_categories(data)
+        if isinstance(categories, tuple):
+            return categories
+        return jsonify({"results": _handle_categories(categories, simple)})
+
+def _get_request_data():
+    """Retrieves and validates the JSON body."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"error": "Cuerpo JSON requerido"}), 400
+    return data
+
+def _get_simple_flag(data):
+    simple_q = request.args.get('simple')
+    if simple_q is not None:
+        return simple_q.lower() == 'true'
+    return bool(data.get('simple')) if 'simple' in data else False
+
+def _parse_names(data):
+    raw = data.get('names')
+    if raw is None:
+        return jsonify({"error": "Campo 'names' requerido en el body"}), 400
+
+    if isinstance(raw, str):
+        items = [n.strip() for n in raw.split(',')]
+    elif isinstance(raw, list):
+        items = [str(n).strip() for n in raw]
+    else:
+        return jsonify({"error": "Campo 'names' debe ser lista o string"}), 400
+
+    names = [n for n in items if n]
+    if not names:
+        return jsonify({"error": "No se encontraron nombres válidos"}), 400
+
+    return names
+
+def _handle_single_name(name, simple):
+    ingredient = ingredient_service.get_ingredient_by_name(name)
+    if ingredient is None:
+        return jsonify({"error": "Ingrediente no encontrado"}), 404
+    return jsonify(
+        {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+    )
+
+def _handle_multiple_names(names, simple):
+    """Searches for multiple ingredients and returns results + missing items."""
+    results = []
+    not_found = []
+
+    for name in names:
+        ingredient = ingredient_service.get_ingredient_by_name(name)
+        if ingredient:
+            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+        else:
+            not_found.append(name)
+
+    return jsonify({"results": results, "not_found": not_found})
+
+def _parse_ids(data):
+    raw = data.get('ids')
+    if not raw:
+        return []
+
+    try:
+        if isinstance(raw, str):
+            items = [int(id.strip()) for id in raw.split(',')]
+        elif isinstance(raw, list):
+            items = [int(id) for id in raw]
+        else:
+            return jsonify({"error": "Campo 'ids' debe ser lista o string"}), 400
+
+        return [id for id in items if id > 0]
+    except ValueError:
+        return jsonify({"error": "Los IDs deben ser números enteros"}), 400
+    
+def _parse_categories(data):
+    raw = data.get('categories')
+    if not raw:
+        return []
+
+    if isinstance(raw, str):
+        items = [cat.strip() for cat in raw.split(',')]
+    elif isinstance(raw, list):
+        items = [str(cat).strip() for cat in raw]
+    else:
+        return jsonify({"error": "Campo 'categories' debe ser lista o string"}), 400
+
+    return [cat for cat in items if cat]
+
+def _handle_multiple_ids(ids, simple):
+    results = []
+    not_found = []
+
+    for id in ids:
+        ingredient = ingredient_service.get_ingredient_by_id(id)
+        if ingredient:
+            results.append(
+                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+            )
+        else:
+            not_found.append(id)
+
+    return {"results": results, "not_found": not_found}
+
+def _handle_categories(categories, simple):
+    results = []
+    for category in categories:
+        ingredients = ingredient_service.get_ingredients_by_category(category)
+        for ingredient in ingredients:
+            results.append(
+                {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+            )
+    return results
+    return jsonify(ingredient.to_json())

--- a/src/API/Ingredients/IngredientsRoutes.py
+++ b/src/API/Ingredients/IngredientsRoutes.py
@@ -7,13 +7,15 @@ ingredients_bp = Blueprint("ingredients", __name__)
 @ingredients_bp.route("/ingredients", methods=["GET"])
 def get_all_ingredients():
     # Check if simplified format is requested
-    simple = request.args.get('simple', 'false').lower() == 'true'
+    simple = request.args.get("simple", "false").lower() == "true"
     ingredients = ingredient_service.get_all_ingredients()
     if simple:
-        return jsonify([{
-            'id': ingredient.id,
-            'name': ingredient.name
-        } for ingredient in ingredients])
+        return jsonify(
+            [
+                {"id": ingredient.id, "name": ingredient.name}
+                for ingredient in ingredients
+            ]
+        )
     return jsonify([ingredient.to_json() for ingredient in ingredients])
 
 
@@ -24,6 +26,7 @@ def get_ingredient_by_id(ingredient_id):
     if not ingredient:
         return jsonify({"error": "Ingrediente no encontrado"}), 404
     return jsonify(ingredient.to_json())
+
 
 @ingredients_bp.route("/ingredients/create", methods=["POST"])
 def create_new_ingredient():
@@ -88,6 +91,7 @@ def delete_ingredient():
 
     return jsonify({"message": "Ingredient deleted successfully"}), 200
 
+
 @ingredients_bp.route("/ingredients/search", methods=["POST"])
 def search_ingredients_body():
     """Search for ingredients by name OR ID OR category"""
@@ -96,17 +100,23 @@ def search_ingredients_body():
         return data
 
     simple = _get_simple_flag(data)
-    
+
     # Verify that only one search criterion is provided
-    search_criteria = [key for key in ['names', 'ids', 'categories'] if key in data]
+    search_criteria = [key for key in ["names", "ids", "categories"] if key in data]
     if len(search_criteria) == 0:
-        return jsonify({
-            "error": "Se requiere un criterio de búsqueda (names, ids, o categories)"
-        }), 400
+        return (
+            jsonify(
+                {
+                    "error": "Se requiere un criterio de búsqueda (names, ids, o categories)"
+                }
+            ),
+            400,
+        )
     if len(search_criteria) > 1:
-        return jsonify({
-            "error": "Solo se permite un criterio de búsqueda a la vez"
-        }), 400
+        return (
+            jsonify({"error": "Solo se permite un criterio de búsqueda a la vez"}),
+            400,
+        )
 
     criterion = search_criteria[0]
     if criterion == "names":
@@ -116,18 +126,19 @@ def search_ingredients_body():
         if len(names) == 1:
             return _handle_single_name(names[0], simple)
         return _handle_multiple_names(names, simple)
-    
-    elif criterion == 'ids':
+
+    elif criterion == "ids":
         ids = _parse_ids(data)
         if isinstance(ids, tuple):
             return ids
         return _handle_multiple_ids(ids, simple)
-    
+
     else:  # categories
         categories = _parse_categories(data)
         if isinstance(categories, tuple):
             return categories
         return _handle_categories(categories, simple)
+
 
 def _get_request_data():
     """Retrieves and validates the JSON body."""
@@ -136,20 +147,22 @@ def _get_request_data():
         return jsonify({"error": "Cuerpo JSON requerido"}), 400
     return data
 
+
 def _get_simple_flag(data):
     """Query param ?simple=true overrides body.simple"""
-    simple_q = request.args.get('simple')
+    simple_q = request.args.get("simple")
     if simple_q is not None:
-        return simple_q.lower() == 'true'
-    return bool(data.get('simple')) if 'simple' in data else False
+        return simple_q.lower() == "true"
+    return bool(data.get("simple")) if "simple" in data else False
+
 
 def _parse_names(data):
-    raw = data.get('names')
+    raw = data.get("names")
     if raw is None:
         return jsonify({"error": "Campo 'names' requerido en el body"}), 400
 
     if isinstance(raw, str):
-        items = [n.strip() for n in raw.split(',')]
+        items = [n.strip() for n in raw.split(",")]
     elif isinstance(raw, list):
         items = [str(n).strip() for n in raw]
     else:
@@ -161,13 +174,17 @@ def _parse_names(data):
 
     return names
 
+
 def _handle_single_name(name, simple):
     ingredient = ingredient_service.get_ingredient_by_name(name)
     if ingredient is None:
         return jsonify({"error": "Ingrediente no encontrado"}), 404
     return jsonify(
-        {'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json()
+        {"id": ingredient.id, "name": ingredient.name}
+        if simple
+        else ingredient.to_json()
     )
+
 
 def _handle_multiple_names(names, simple):
     """Searches for multiple ingredients and returns results + missing items."""
@@ -176,19 +193,24 @@ def _handle_multiple_names(names, simple):
     for name in names:
         ingredient = ingredient_service.get_ingredient_by_name(name)
         if ingredient:
-            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+            results.append(
+                {"id": ingredient.id, "name": ingredient.name}
+                if simple
+                else ingredient.to_json()
+            )
         else:
             not_found.append(name)
     return jsonify({"results": results, "not_found": not_found}), 200
 
+
 def _parse_ids(data):
-    raw = data.get('ids')
+    raw = data.get("ids")
     if not raw:
         return []
 
     try:
         if isinstance(raw, str):
-            items = [int(id.strip()) for id in raw.split(',')]
+            items = [int(id.strip()) for id in raw.split(",")]
         elif isinstance(raw, list):
             items = [int(id) for id in raw]
         else:
@@ -197,14 +219,15 @@ def _parse_ids(data):
         return [id for id in items if id > 0]
     except ValueError:
         return jsonify({"error": "Los IDs deben ser números enteros"}), 400
-    
+
+
 def _parse_categories(data):
-    raw = data.get('categories')
+    raw = data.get("categories")
     if not raw:
         return []
 
     if isinstance(raw, str):
-        items = [cat.strip() for cat in raw.split(',')]
+        items = [cat.strip() for cat in raw.split(",")]
     elif isinstance(raw, list):
         items = [str(cat).strip() for cat in raw]
     else:
@@ -212,23 +235,33 @@ def _parse_categories(data):
 
     return [cat for cat in items if cat]
 
+
 def _handle_multiple_ids(ids, simple):
     results = []
     not_found = []
     for iid in ids:
         ingredient = ingredient_service.get_ingredient_by_id(iid)
         if ingredient:
-            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+            results.append(
+                {"id": ingredient.id, "name": ingredient.name}
+                if simple
+                else ingredient.to_json()
+            )
         else:
             not_found.append(iid)
     return jsonify({"results": results, "not_found": not_found}), 200
+
 
 def _handle_categories(categories, simple):
     results = []
     for category in categories:
         ingredients = ingredient_service.get_ingredients_by_category(category)
         for ingredient in ingredients:
-            results.append({'id': ingredient.id, 'name': ingredient.name} if simple else ingredient.to_json())
+            results.append(
+                {"id": ingredient.id, "name": ingredient.name}
+                if simple
+                else ingredient.to_json()
+            )
     # remove duplicates by id
     unique = []
     seen = set()

--- a/src/Application/Ingredients/IngredientUseCase.py
+++ b/src/Application/Ingredients/IngredientUseCase.py
@@ -46,6 +46,10 @@ class IngredientUseCase:
     def delete_ingredient(self, ingredient_id: int):
         """Delete an ingredient from the ingredient dictionary"""
         return self.repository.delete_ingredient(ingredient_id)
+    
+    def get_ingredients_by_category(self, ingredient_category: str) -> List[Ingredient]:
+        """Get all ingredients that belong to a specific category."""
+        return self.repository.get_by_category(ingredient_category)
 
 
 # Create a singleton instance to be imported by the routes

--- a/src/Application/Ingredients/IngredientUseCase.py
+++ b/src/Application/Ingredients/IngredientUseCase.py
@@ -46,7 +46,7 @@ class IngredientUseCase:
     def delete_ingredient(self, ingredient_id: int):
         """Delete an ingredient from the ingredient dictionary"""
         return self.repository.delete_ingredient(ingredient_id)
-    
+
     def get_ingredients_by_category(self, ingredient_category: str) -> List[Ingredient]:
         """Get all ingredients that belong to a specific category."""
         return self.repository.get_by_category(ingredient_category)

--- a/tests/Unittests/Ingredients/test_ingredient_service.py
+++ b/tests/Unittests/Ingredients/test_ingredient_service.py
@@ -162,6 +162,90 @@ class IngredientServiceTestCase(unittest.TestCase):
         self.assertEqual(data["error"], "Ingredient not found")
         mock_service.delete_ingredient.assert_called_once()
 
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_multiple_names_returns_results_and_not_found(self, mock_service):
+        # setup: "tomate" exists, "cebolla" does not
+        tomate = Mock()
+        tomate.id = 1
+        tomate.name = "tomate"
+        tomate.to_json.return_value = {"id": 1, "name": "tomate"}
+
+        def get_by_name_side(name):
+            return tomate if name.lower() == "tomate" else None
+
+        mock_service.get_ingredient_by_name.side_effect = get_by_name_side
+
+        resp = self.client.post("/ingredients/search", json={"names": ["tomate", "cebolla"]})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn("results", data)
+        self.assertIn("not_found", data)
+        self.assertTrue(any(item["id"] == 1 for item in data["results"]))
+        self.assertIn("cebolla", data["not_found"])
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_single_name_not_found_returns_404(self, mock_service):
+        mock_service.get_ingredient_by_name.return_value = None
+        resp = self.client.post("/ingredients/search", json={"names": "noexist"})
+        self.assertEqual(resp.status_code, 404)
+        data = resp.get_json()
+        self.assertIn("error", data)
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_ids_returns_results_and_not_found(self, mock_service):
+        # id 1 exists, id 2 does not
+        ingr1 = Mock()
+        ingr1.id = 1
+        ingr1.name = "A"
+        ingr1.to_json.return_value = {"id": 1, "name": "A"}
+
+        def get_by_id_side(i):
+            return ingr1 if i == 1 else None
+
+        mock_service.get_ingredient_by_id.side_effect = get_by_id_side
+
+        resp = self.client.post("/ingredients/search", json={"ids": [1, 2]})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn("results", data)
+        self.assertIn("not_found", data)
+        self.assertTrue(any(item["id"] == 1 for item in data["results"]))
+        self.assertIn(2, data["not_found"])
+
+    @patch("src.API.Ingredients.IngredientsRoutes.ingredient_service")
+    def test_search_by_categories_returns_matching_ingredients(self, mock_service):
+        milk = Mock()
+        milk.id = 10
+        milk.name = "Whole Milk"
+        milk.to_json.return_value = {"id": 10, "name": "Whole Milk"}
+
+        butter = Mock()
+        butter.id = 11
+        butter.name = "Butter"
+        butter.to_json.return_value = {"id": 11, "name": "Butter"}
+
+        mock_service.get_ingredients_by_category.return_value = [milk, butter]
+
+        resp = self.client.post("/ingredients/search", json={"categories": ["dairy"]})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn("results", data)
+        ids = {r["id"] for r in data["results"]}
+        self.assertIn(10, ids)
+        self.assertIn(11, ids)
+
+    def test_search_combined_criteria_returns_400(self):
+        resp = self.client.post("/ingredients/search", json={"names": ["a"], "ids": [1]})
+        self.assertEqual(resp.status_code, 400)
+        data = resp.get_json()
+        self.assertIn("error", data)
+
+    def test_search_missing_body_returns_400(self):
+        # no JSON body -> error
+        resp = self.client.post("/ingredients/search")
+        self.assertEqual(resp.status_code, 400)
+        data = resp.get_json()
+        self.assertIn("error", data)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/Unittests/Ingredients/test_ingredient_service.py
+++ b/tests/Unittests/Ingredients/test_ingredient_service.py
@@ -175,7 +175,9 @@ class IngredientServiceTestCase(unittest.TestCase):
 
         mock_service.get_ingredient_by_name.side_effect = get_by_name_side
 
-        resp = self.client.post("/ingredients/search", json={"names": ["tomate", "cebolla"]})
+        resp = self.client.post(
+            "/ingredients/search", json={"names": ["tomate", "cebolla"]}
+        )
         self.assertEqual(resp.status_code, 200)
         data = resp.get_json()
         self.assertIn("results", data)
@@ -235,7 +237,9 @@ class IngredientServiceTestCase(unittest.TestCase):
         self.assertIn(11, ids)
 
     def test_search_combined_criteria_returns_400(self):
-        resp = self.client.post("/ingredients/search", json={"names": ["a"], "ids": [1]})
+        resp = self.client.post(
+            "/ingredients/search", json={"names": ["a"], "ids": [1]}
+        )
         self.assertEqual(resp.status_code, 400)
         data = resp.get_json()
         self.assertIn("error", data)
@@ -246,6 +250,7 @@ class IngredientServiceTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         data = resp.get_json()
         self.assertIn("error", data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Correction of the get Ingredient search feature from Pull request #83.

Includes:
- Adding to the URL ```http://localhost:5000/api/ingredients/search?simple=true``` now displays the simplified form of that ingredient. The same use cases are in pr #83
- Search functionality tests